### PR TITLE
chore(report): only overide folders and files of the report site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ node_modules/
 .eslintcache
 coverage
 output
+tools/automation/report/.vuepress/dist
+tools/automation/report/che-plugin-registry

--- a/tools/automation/.ci/publish-report.sh
+++ b/tools/automation/.ci/publish-report.sh
@@ -18,11 +18,13 @@ yarn run compile
 node ./lib/check-plugin-updates.js
 cd ./report
 ../../../node_modules/.bin/vuepress build
-cd ./.vuepress/dist
 git config --global user.email "che-bot@eclipse.org"
 git config --global user.name "CHE Bot"
-git init .
-git checkout --orphan gh-pages
-git add ./*
-git commit -m "Automated Plugin Report $DATE_TIME" -s
-git push -f "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/eclipse-che/che-plugin-registry.git" gh-pages
+rm -rf che-plugin-registry
+git clone -b gh-pages "https://github.com/$GITHUB_REPOSITORY.git"
+cd che-plugin-registry
+git rm -r assets *.html
+cp -rf ../.vuepress/dist/* .
+git add assets *.html
+git commit -m "Automated Plugin Report - $(date)" -s
+git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" gh-pages

--- a/tools/automation/.ci/publish-report.sh
+++ b/tools/automation/.ci/publish-report.sh
@@ -23,8 +23,8 @@ git config --global user.name "CHE Bot"
 rm -rf che-plugin-registry
 git clone -b gh-pages "https://github.com/$GITHUB_REPOSITORY.git"
 cd che-plugin-registry
-git rm -r assets *.html
+git rm -r assets ./*.html
 cp -rf ../.vuepress/dist/* .
-git add assets *.html
+git add assets ./*.html
 git commit -m "Automated Plugin Report - $(date)" -s
 git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" gh-pages


### PR DESCRIPTION
### What does this PR do?
Update report site publishing so it doesn't override other sites that may be published in the same gh-pages branch but sub-directories.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/19268: registries for each version would be published in sub-directories and should not be overriden.


### How to test this PR?
1. fork the che-plugin-registry github (including gh-pages branch)
2. clone the original che-plugin-registry and checkout this `report-gh-pages-keep-history` branch
3. set the env variables (adapt it to use your fork/credentials):
   ```
   export GITHUB_TOKEN=xxx
   export GITHUB_ACTOR=sunix
   export GITHUB_REPOSITORY=sunix/che-plugin-registry
   ```
4. build and publish:
   ```
   cd che-plugin-registry
   ./tools/automation/.ci/publish-report.sh
   ```
5. check the history in your fork gh-pages branch for instance: https://github.com/sunix/che-plugin-registry/commits/gh-pages
6. check that the gh-pages works well. for instance: https://sunix.github.io/che-plugin-registry/

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
