### PR TITLE
feat(plugins): generate che-theia-plugin.yaml fragment in addition to meta.yaml for VS Code extensions

### DIFF
--- a/tools/build/src/build.ts
+++ b/tools/build/src/build.ts
@@ -26,6 +26,8 @@ import { CheTheiaPluginAnalyzerMetaInfo } from './che-theia-plugin/che-theia-plu
 import { CheTheiaPluginYaml } from './che-theia-plugin/che-theia-plugins-yaml';
 import { CheTheiaPluginsAnalyzer } from './che-theia-plugin/che-theia-plugins-analyzer';
 import { CheTheiaPluginsMetaYamlGenerator } from './che-theia-plugin/che-theia-plugins-meta-yaml-generator';
+import { CheTheiaPluginsYamlGenerator } from './che-theia-plugin/che-theia-plugins-yaml-generator';
+import { CheTheiaPluginsYamlWriter } from './che-theia-plugin/che-theia-plugins-yaml-writer';
 import { Deferred } from './util/deferred';
 import { DigestImagesHelper } from './meta-yaml/digest-images-helper';
 import { ExternalImagesWriter } from './meta-yaml/external-images-writer';
@@ -72,6 +74,9 @@ export class Build {
   @inject(CheTheiaPluginsMetaYamlGenerator)
   private cheTheiaPluginsMetaYamlGenerator: CheTheiaPluginsMetaYamlGenerator;
 
+  @inject(CheTheiaPluginsYamlGenerator)
+  private cheTheiaPluginsYamlGenerator: CheTheiaPluginsYamlGenerator;
+
   @inject(CheEditorsMetaYamlGenerator)
   private cheEditorsMetaYamlGenerator: CheEditorsMetaYamlGenerator;
 
@@ -80,6 +85,9 @@ export class Build {
 
   @inject(MetaYamlWriter)
   private metaYamlWriter: MetaYamlWriter;
+
+  @inject(CheTheiaPluginsYamlWriter)
+  private cheTheiaPluginsYamlWriter: CheTheiaPluginsYamlWriter;
 
   @inject(ExternalImagesWriter)
   private externalImagesWriter: ExternalImagesWriter;
@@ -273,6 +281,10 @@ export class Build {
       'Compute meta.yaml for che-theia-plugins',
       this.cheTheiaPluginsMetaYamlGenerator.compute(cheTheiaPlugins)
     );
+    const cheTheiaPluginsYaml = await this.wrapIntoTask(
+      'Compute che-theia-plugin.yaml fragments for che-theia-plugins',
+      this.cheTheiaPluginsYamlGenerator.compute(cheTheiaPlugins)
+    );
 
     const cheEditors = await this.wrapIntoTask('Analyze che-editors.yaml file', this.analyzeCheEditorsYaml());
     const cheEditorsMetaYaml = await this.wrapIntoTask(
@@ -302,6 +314,12 @@ export class Build {
     const generatedYamls = await this.wrapIntoTask(
       'Write meta.yamls in v3/plugins folder',
       this.metaYamlWriter.write(allMetaYamls)
+    );
+
+    // write che-theia-plugins fragment
+    await this.wrapIntoTask(
+      'Write che-theia-plugin.yaml fragment in v3/plugins folder',
+      this.cheTheiaPluginsYamlWriter.write(cheTheiaPluginsYaml)
     );
 
     // generate index.json

--- a/tools/build/src/che-theia-plugin/che-theia-plugin-module.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugin-module.ts
@@ -11,10 +11,14 @@ import { ContainerModule, interfaces } from 'inversify';
 
 import { CheTheiaPluginsAnalyzer } from './che-theia-plugins-analyzer';
 import { CheTheiaPluginsMetaYamlGenerator } from './che-theia-plugins-meta-yaml-generator';
+import { CheTheiaPluginsYamlGenerator } from './che-theia-plugins-yaml-generator';
+import { CheTheiaPluginsYamlWriter } from './che-theia-plugins-yaml-writer';
 
 const cheTheiaPluginModule = new ContainerModule((bind: interfaces.Bind) => {
   bind(CheTheiaPluginsAnalyzer).toSelf().inSingletonScope();
   bind(CheTheiaPluginsMetaYamlGenerator).toSelf().inSingletonScope();
+  bind(CheTheiaPluginsYamlGenerator).toSelf().inSingletonScope();
+  bind(CheTheiaPluginsYamlWriter).toSelf().inSingletonScope();
 });
 
 export { cheTheiaPluginModule };

--- a/tools/build/src/che-theia-plugin/che-theia-plugin-yaml-info.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugin-yaml-info.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { VsixCategory, VsixInfo } from '../extensions/vsix-info';
+
+import { CheTheiaPluginSidecarImageYaml } from './che-theia-plugins-yaml';
+
+export interface CheTheiaPluginYamlInfo {
+  aliases?: string[];
+  vsixInfos: Map<string, VsixInfo>;
+  data: {
+    schemaVersion: string;
+    metadata: {
+      id: string;
+      publisher: string;
+      name: string;
+      version: string;
+      displayName: string;
+      description: string;
+      iconFile?: string;
+      repository: string;
+      categories: VsixCategory[];
+    };
+    sidecar?: CheTheiaPluginSidecarImageYaml;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    preferences?: { [key: string]: any };
+    extensions: string[];
+  };
+}

--- a/tools/build/src/che-theia-plugin/che-theia-plugins-yaml-generator.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugins-yaml-generator.ts
@@ -1,0 +1,152 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import * as path from 'path';
+
+import { VsixCategory, VsixInfo } from '../extensions/vsix-info';
+import { inject, injectable } from 'inversify';
+
+import { CheTheiaPluginMetaInfo } from '../build';
+import { CheTheiaPluginYamlInfo } from './che-theia-plugin-yaml-info';
+import { Sidecar } from '../sidecar/sidecar';
+
+@injectable()
+export class CheTheiaPluginsYamlGenerator {
+  static readonly CHE_THEIA_SIDECAR_PREFERENCES = 'CHE_THEIA_SIDECAR_PREFERENCES';
+
+  @inject(Sidecar)
+  private sidecar: Sidecar;
+
+  readI18nProperty(propertyName: string | undefined, vsixInfo: VsixInfo): string {
+    if (!propertyName) {
+      return '';
+    }
+    if (propertyName && propertyName.startsWith('%') && propertyName.endsWith('%')) {
+      const propertyWithoutPrefixSuffix = propertyName.substring(1, propertyName.length - 1);
+      // need to look if there is i18n
+      const nls = vsixInfo.packageNlsJson;
+      if (nls) {
+        return nls[propertyWithoutPrefixSuffix];
+      }
+    }
+    return propertyName;
+  }
+
+  async compute(cheTheiaPlugins: CheTheiaPluginMetaInfo[]): Promise<CheTheiaPluginYamlInfo[]> {
+    // for each plugin, compute info
+    const yamlPluginInfos: CheTheiaPluginYamlInfo[] = await Promise.all(
+      cheTheiaPlugins.map(async (chePlugin: CheTheiaPluginMetaInfo) => {
+        const vsixData = Array.from(chePlugin.vsixInfos.values());
+        const firstVsix = vsixData[0];
+        const packageJson = firstVsix.packageJson;
+
+        const chePluginOutput = JSON.stringify(chePlugin);
+
+        if (!packageJson) {
+          throw new Error(`No package.json found for ${chePluginOutput}`);
+        }
+        if (!packageJson.publisher) {
+          throw new Error(`No publisher field in package.json found for ${chePluginOutput}`);
+        }
+        const publisher: string = packageJson.publisher.toLowerCase();
+        if (!packageJson.name) {
+          throw new Error(`No name field in package.json found for ${chePluginOutput}`);
+        }
+        const name: string = packageJson.name.toLowerCase();
+
+        if (!packageJson.version) {
+          throw new Error(`No version field in package.json found for ${chePluginOutput}`);
+        }
+        const version: string = packageJson.version;
+
+        const displayName: string = this.readI18nProperty(packageJson.displayName, firstVsix);
+
+        const description = this.readI18nProperty(packageJson.description, firstVsix);
+
+        let categories: VsixCategory[];
+        if (!packageJson.categories || packageJson.categories.length === 0) {
+          console.error(`No categories field in package.json found for ${chePluginOutput}. Using Other type`);
+          categories = ['Other'];
+        } else {
+          // take first category
+          categories = packageJson.categories;
+        }
+
+        if (!packageJson.icon) {
+          console.warn(`No icon field in package.json found for ${chePluginOutput}`);
+        }
+        let iconFile: string | undefined;
+        if (packageJson.icon && firstVsix.unpackedExtensionRootDir) {
+          iconFile = path.resolve(firstVsix.unpackedExtensionRootDir, packageJson.icon);
+        }
+
+        let repository: string;
+        if (packageJson.repository && typeof packageJson.repository === 'string') {
+          repository = packageJson.repository;
+        } else if (
+          packageJson.repository &&
+          packageJson.repository.url &&
+          typeof packageJson.repository.url === 'string'
+        ) {
+          repository = packageJson.repository.url;
+        } else {
+          // take definition from the yaml
+          repository = chePlugin.repository.url;
+          console.warn(
+            `repository field is not a string or repository.url missing in package.json found, using the one from yaml content for ${chePluginOutput}`
+          );
+        }
+
+        const id = chePlugin.id;
+
+        const preferences = chePlugin.preferences;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let sidecarContainer: any;
+
+        // list of vsix
+        const extensions = chePlugin.extensions;
+
+        // list of vsix
+        const vsixInfos = chePlugin.vsixInfos;
+
+        if (chePlugin.sidecar) {
+          const sidecarImage = await this.sidecar.getDockerImageFor(chePlugin);
+          sidecarContainer = { ...chePlugin.sidecar, image: sidecarImage };
+          // remove definition of the docker image source folder
+          delete sidecarContainer.directory;
+        }
+
+        return {
+          aliases: chePlugin.aliases,
+          vsixInfos,
+          data: {
+            schemaVersion: '1.0.0',
+            metadata: {
+              id,
+              publisher,
+              name,
+              version,
+              displayName,
+              description,
+              iconFile,
+              repository,
+              categories,
+            },
+            sidecar: sidecarContainer,
+            preferences,
+            extensions,
+          },
+        };
+      })
+    );
+
+    return yamlPluginInfos;
+  }
+}

--- a/tools/build/src/che-theia-plugin/che-theia-plugins-yaml-writer.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugins-yaml-writer.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as fs from 'fs-extra';
+import * as jsyaml from 'js-yaml';
+import * as path from 'path';
+
+import { inject, injectable, named } from 'inversify';
+
+import { CheTheiaPluginYamlInfo } from './che-theia-plugin-yaml-info';
+
+@injectable()
+export class CheTheiaPluginsYamlWriter {
+  @inject('string')
+  @named('OUTPUT_ROOT_DIRECTORY')
+  private outputRootDirectory: string;
+
+  @inject('boolean')
+  @named('EMBED_VSIX')
+  private embedVsix: boolean;
+
+  public static readonly DEFAULT_ICON = '/v3/images/eclipse-che-logo.png';
+
+  convertIdToPublisherAndName(id: string): [string, string] {
+    const values = id.split('/');
+    return [values[0], values[1]];
+  }
+
+  async write(cheTheiaPluginYamlInfos: CheTheiaPluginYamlInfo[]): Promise<void> {
+    // now, write the files
+    const pluginsFolder = path.resolve(this.outputRootDirectory, 'v3', 'plugins');
+    await fs.ensureDir(pluginsFolder);
+    const imagesFolder = path.resolve(this.outputRootDirectory, 'v3', 'images');
+    await fs.ensureDir(imagesFolder);
+    const resourcesFolder = path.resolve(this.outputRootDirectory, 'v3', 'resources');
+    await fs.ensureDir(resourcesFolder);
+
+    await Promise.all(
+      cheTheiaPluginYamlInfos.map(async cheTheiaPluginYamlInfo => {
+        const { aliases, data, vsixInfos } = cheTheiaPluginYamlInfo;
+        const iconFile = data.metadata.iconFile;
+        // write icon if iconfFile is specified or use default icon
+        let icon: string;
+        if (iconFile) {
+          // write icon in v3/images folder
+          const fileExtensionIcon = path.extname(path.basename(iconFile)).toLowerCase();
+          const destIconFileName = `${data.metadata.publisher}-${data.metadata.name}-icon${fileExtensionIcon}`;
+          await fs.copyFile(iconFile, path.resolve(imagesFolder, destIconFileName));
+          icon = `/v3/images/${destIconFileName}`;
+        } else {
+          icon = CheTheiaPluginsYamlWriter.DEFAULT_ICON;
+        }
+
+        // copy vsix for offline storage
+        if (this.embedVsix) {
+          // need to write vsix file downloaded
+          await Promise.all(
+            data.extensions.map(async (extension, index) => {
+              const vsixInfo = vsixInfos.get(extension);
+              if (vsixInfo && vsixInfo.downloadedArchive) {
+                const directoryPattern = path
+                  .dirname(extension)
+                  .replace('http://', '')
+                  .replace('https://', '')
+                  .replace(/[^a-zA-Z0-9-/]/g, '_');
+                const filePattern = path.basename(extension);
+                const destFolder = path.join(resourcesFolder, directoryPattern);
+                const destFile = path.join(destFolder, filePattern);
+                await fs.ensureDir(destFolder);
+                await fs.copyFile(vsixInfo.downloadedArchive, destFile);
+                data.extensions[index] = `relative:extension/resources/${directoryPattern}/${filePattern}`;
+              }
+            })
+          );
+        }
+        const promises: Promise<unknown>[] = [];
+        // write content
+        // const computedId = `${data.metadata.publisher}/${data.metadata.name}`;
+        const convertedValue = this.convertIdToPublisherAndName(data.metadata.id);
+        const generatedPublisher = convertedValue[0];
+        const generatedName = convertedValue[1];
+
+        // add spec object
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const writingData: any = {
+          ...data,
+        };
+        writingData.metadata.icon = icon;
+        delete writingData.metadata.iconFile;
+        // remove undefined fields
+        const newAliases = aliases || [];
+        // add current name before all aliases
+        newAliases.unshift(`${generatedPublisher}/${generatedName}`);
+        newAliases.forEach(async alias => {
+          const publisherAndName = this.convertIdToPublisherAndName(alias);
+          const writingPublisher = publisherAndName[0];
+          const writingName = publisherAndName[1];
+          const writingId = `${writingPublisher}/${writingName}`;
+          const cleanupWritingData = JSON.parse(JSON.stringify(writingData));
+          cleanupWritingData.metadata.id = writingId;
+          cleanupWritingData.metadata.publisher = writingPublisher;
+          cleanupWritingData.metadata.name = writingName;
+          cleanupWritingData.metadata.version = 'latest';
+          const yamlString = jsyaml.safeDump(cleanupWritingData, { lineWidth: 120 });
+          const pluginPath = path.resolve(pluginsFolder, alias, 'latest', 'che-theia-plugin.yaml');
+          await fs.ensureDir(path.dirname(pluginPath));
+          promises.push(fs.writeFile(pluginPath, yamlString));
+        });
+      })
+    );
+  }
+}

--- a/tools/build/src/common/container-helper.ts
+++ b/tools/build/src/common/container-helper.ts
@@ -37,7 +37,8 @@ export class ContainerHelper {
       const volumes = new Map<string, CheEditorVolume>();
       editor.components
         .filter(c => c.name && c.volume && Object.keys(c.volume).length > 0)
-        .forEach(c => volumes.set(c.name!, c.volume!));
+        .map(c => c as { name: string; volume: CheEditorVolume })
+        .forEach(c => volumes.set(c.name, c.volume));
       editor.components
         .filter(c => c.container)
         .forEach(component => {

--- a/tools/build/src/meta-yaml/index-writer.ts
+++ b/tools/build/src/meta-yaml/index-writer.ts
@@ -25,11 +25,13 @@ export class IndexWriter {
   private outputRootDirectory: string;
 
   getLinks(plugin: MetaYamlPluginInfo): { self: string; devfile?: string } {
-    const links: { self: string; devfile?: string } = {
+    const links: { self: string; devfile?: string; plugin?: string } = {
       self: `/v3/plugins/${plugin.id}`,
     };
     if (plugin.type === 'Che Editor' || plugin.type === 'Che Plugin') {
       links.devfile = `/v3/plugins/${plugin.id}/devfile.yaml`;
+    } else if (plugin.type === 'VS Code extension') {
+      links.plugin = `/v3/plugins/${plugin.id}/che-theia-plugin.yaml`;
     }
     return links;
   }

--- a/tools/build/tests/build.spec.ts
+++ b/tools/build/tests/build.spec.ts
@@ -23,6 +23,8 @@ import { ChePluginsMetaYamlGenerator } from '../src/che-plugin/che-plugins-meta-
 import { CheTheiaPluginAnalyzerMetaInfo } from '../src/che-theia-plugin/che-theia-plugin-analyzer-meta-info';
 import { CheTheiaPluginsAnalyzer } from '../src/che-theia-plugin/che-theia-plugins-analyzer';
 import { CheTheiaPluginsMetaYamlGenerator } from '../src/che-theia-plugin/che-theia-plugins-meta-yaml-generator';
+import { CheTheiaPluginsYamlGenerator } from '../src/che-theia-plugin/che-theia-plugins-yaml-generator';
+import { CheTheiaPluginsYamlWriter } from '../src/che-theia-plugin/che-theia-plugins-yaml-writer';
 import { Container } from 'inversify';
 import { Deferred } from '../src/util/deferred';
 import { DigestImagesHelper } from '../src/meta-yaml/digest-images-helper';
@@ -115,6 +117,16 @@ describe('Test Build', () => {
   const metaYamlEditorGeneratorComputeMock = jest.fn();
   const cheEditorMetaYamlGenerator: any = {
     compute: metaYamlEditorGeneratorComputeMock,
+  };
+
+  const cheTheiaPluginsYamlWriterWriteMock = jest.fn();
+  const cheTheiaPluginsYamlWriter: any = {
+    write: cheTheiaPluginsYamlWriterWriteMock,
+  };
+
+  const cheTheiaPluginsYamlGeneratorComputeMock = jest.fn();
+  const cheTheiaPluginsYamlGenerator: any = {
+    compute: cheTheiaPluginsYamlGeneratorComputeMock,
   };
 
   let build: Build;
@@ -213,6 +225,8 @@ describe('Test Build', () => {
 
     container.bind(CheTheiaPluginsAnalyzer).toConstantValue(cheTheiaPluginsAnalyzer);
     container.bind(CheTheiaPluginsMetaYamlGenerator).toConstantValue(cheTheiaPluginsMetaYamlGenerator);
+    container.bind(CheTheiaPluginsYamlWriter).toConstantValue(cheTheiaPluginsYamlWriter);
+    container.bind(CheTheiaPluginsYamlGenerator).toConstantValue(cheTheiaPluginsYamlGenerator);
     container.bind(ChePluginsAnalyzer).toConstantValue(chePluginsAnalyzer);
     container.bind(ChePluginsMetaYamlGenerator).toConstantValue(chePluginsMetaYamlGenerator);
     container.bind(CheEditorsAnalyzer).toConstantValue(cheEditorsAnalyzer);
@@ -276,6 +290,8 @@ describe('Test Build', () => {
     expect(externalImagesWriter.write).toBeCalled();
     expect(metaYamlWriter.write).toBeCalled();
     expect(indexWriter.write).toBeCalled();
+    expect(cheTheiaPluginsYamlWriter.write).toBeCalled();
+    expect(cheTheiaPluginsYamlGenerator.compute).toBeCalled();
   });
 
   test('basics without package.json', async () => {

--- a/tools/build/tests/che-theia-plugin/che-theia-plugins-yaml-generator.spec.ts
+++ b/tools/build/tests/che-theia-plugin/che-theia-plugins-yaml-generator.spec.ts
@@ -1,0 +1,347 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { CheTheiaPluginAnalyzerMetaInfo } from '../../src/che-theia-plugin/che-theia-plugin-analyzer-meta-info';
+import { CheTheiaPluginMetaInfo } from '../../src/build';
+import { CheTheiaPluginsYamlGenerator } from '../../src/che-theia-plugin/che-theia-plugins-yaml-generator';
+import { Container } from 'inversify';
+import { Sidecar } from '../../src/sidecar/sidecar';
+import { VsixInfo } from '../../src/extensions/vsix-info';
+
+describe('Test CheTheiaPluginsYamlGenerator', () => {
+  let container: Container;
+
+  let cheTheiaPluginsYamlGenerator: CheTheiaPluginsYamlGenerator;
+  const originalConsoleWarn: any = console.warn;
+  const originalConsoleError: any = console.error;
+
+  const fakeImage = 'quay-fake.io/my-image:123';
+
+  const sideCarGetDockerImageFor = jest.fn();
+  const sidecar: any = {
+    getDockerImageFor: sideCarGetDockerImageFor,
+  };
+
+  async function generatePluginMetaInfo(id: string): Promise<CheTheiaPluginMetaInfo> {
+    const extensionLink = 'https://fake-first.vsix';
+    const vscodeGoPackageJsonPath = path.resolve(__dirname, '..', '_data', 'packages', 'vscode-go-package.json');
+    const vscodeGoPackageJsonContent = await fs.readFile(vscodeGoPackageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(vscodeGoPackageJsonContent);
+    const packageNlsJson = {
+      key1: 'value1',
+    };
+    const vsixInfos = new Map<string, VsixInfo>();
+
+    const cheTheiaPluginId = id;
+    const cheTheiaPlugin: CheTheiaPluginAnalyzerMetaInfo = {
+      id: cheTheiaPluginId,
+      featured: false,
+      aliases: [],
+      preferences: {
+        'my.preferences1': true,
+        'debug.node.useV3': false,
+      },
+      sidecar: {
+        name: 'my-name',
+        memoryRequest: '1m',
+        memoryLimit: '2m',
+        cpuRequest: '3m',
+        cpuLimit: '4m',
+        command: ['/bin/sh'],
+        args: ['-c', './entrypoint.sh'],
+        env: [
+          {
+            name: 'my-env-name',
+            value: 'my-env-value',
+          },
+        ],
+        mountSources: true,
+        endpoints: [
+          {
+            name: 'configuration-endpoint',
+            public: true,
+            targetPort: 61436,
+            attributes: {
+              protocol: 'http',
+            },
+          },
+          {
+            name: 'report-endpoint',
+            public: true,
+            targetPort: 61435,
+            attributes: {
+              protocol: 'http',
+            },
+          },
+        ],
+        volumeMounts: [
+          { path: '/home/theia/.ivy2', name: 'ivy2' },
+          { path: '/home/theia/.m2', name: '.m2' },
+        ],
+        image: 'fake-image',
+      },
+      extensions: [extensionLink],
+      repository: {
+        url: 'http://fake-repo',
+        revision: 'main',
+      },
+      vsixInfos,
+    };
+    const vsixInfo: VsixInfo = {
+      uri: 'http://www.fake.uri',
+      cheTheiaPlugin,
+      downloadedArchive: '/fake/downloaded-archive',
+      unpackedArchive: '/fake/unpacked-archive',
+      creationDate: '2020-01-01',
+      unpackedExtensionRootDir: '/fake/root-dir',
+      packageJson,
+      packageNlsJson,
+    };
+
+    vsixInfos.set(extensionLink, vsixInfo);
+    const cheTheiaPluginMetaInfo: CheTheiaPluginMetaInfo = {
+      ...cheTheiaPlugin,
+      id: cheTheiaPluginId,
+    };
+    return cheTheiaPluginMetaInfo;
+  }
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    console.error = jest.fn();
+    console.warn = jest.fn();
+    container = new Container();
+    container.bind(CheTheiaPluginsYamlGenerator).toSelf().inSingletonScope();
+    container.bind(Sidecar).toConstantValue(sidecar);
+    sideCarGetDockerImageFor.mockResolvedValue(fakeImage);
+    cheTheiaPluginsYamlGenerator = container.get(CheTheiaPluginsYamlGenerator);
+  });
+  afterEach(() => {
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+  });
+
+  test('basics', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    const metaYamlInfo = result[0];
+
+    const data = metaYamlInfo.data;
+    expect(data).toBeDefined();
+    const sidecarContainer = data.sidecar;
+    if (!sidecarContainer) {
+      throw new Error('No spec containers');
+    }
+    expect(sidecarContainer).toBeDefined();
+    expect(sidecarContainer.image).toBe(fakeImage);
+    expect(sidecarContainer.command).toStrictEqual(['/bin/sh']);
+    expect(sidecarContainer.args).toStrictEqual(['-c', './entrypoint.sh']);
+    expect(data.preferences).toBeDefined();
+    expect(data.preferences).toEqual({ 'debug.node.useV3': false, 'my.preferences1': true });
+  });
+
+  test('basics without sidecar', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    delete cheTheiaPluginMetaInfo.sidecar;
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    const metaYamlInfo = result[0];
+    const data = metaYamlInfo.data;
+    expect(data).toBeDefined();
+    const sidecarContainer = data.sidecar;
+    expect(sidecarContainer).toBeUndefined();
+    expect(data.preferences).toBeDefined();
+    expect(data.preferences).toEqual({ 'debug.node.useV3': false, 'my.preferences1': true });
+  });
+
+  test('nls property without property', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    // remove preferences as well
+    delete cheTheiaPluginMetaInfo.preferences;
+
+    delete Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageNlsJson;
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+
+    // undefined displayName
+    if (packageJson) {
+      delete packageJson.displayName;
+    } else {
+      throw new Error('invalid setup');
+    }
+
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    // property is not replaced by nls as it is not there
+    expect(result[0].data.metadata.description).toBe(packageJson.description);
+  });
+
+  test('nls property without nls field', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    // remove preferences as well
+    delete cheTheiaPluginMetaInfo.preferences;
+
+    delete Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageNlsJson;
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    if (packageJson) {
+      packageJson.description = '%my-nls-description%';
+    } else {
+      throw new Error('invalid setup');
+    }
+
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    // property is not replaced by nls as it is not there
+    expect(result[0].data.metadata.description).toBe(packageJson.description);
+  });
+
+  test('nls property with nls field', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const nslPackageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageNlsJson;
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    const nslPropertyName = '%my-nls-description%';
+    const nslPropertyValue = 'my-value-specified-in-nls';
+
+    if (packageJson && nslPackageJson) {
+      packageJson.description = nslPropertyName;
+      nslPackageJson[nslPropertyName.substring(1, nslPropertyName.length - 1)] = nslPropertyValue;
+    } else {
+      throw new Error('invalid setup');
+    }
+
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    // property is replaced by nls as it is specified
+    expect(result[0].data.metadata.description).toBe(nslPropertyValue);
+  });
+
+  test('no category should use the default category instead', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    if (packageJson) {
+      packageJson.categories = [];
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0].data.metadata.categories).toStrictEqual(['Other']);
+    expect(console.error as jest.Mock).toBeCalled();
+    const call = (console.error as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('No categories field in package.json found for');
+  });
+
+  test('repository in simple format should work as well', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    const fakeRepository = 'http://my-fake-repository';
+    if (packageJson) {
+      (packageJson.repository as any) = fakeRepository;
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0].data.metadata.repository).toBe(fakeRepository);
+  });
+
+  test('invalid repository in package.json should take repository from yaml', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    const fakeRepository = 'http://my-fake-repository';
+    if (packageJson) {
+      // use invalid struct
+      (packageJson.repository as any) = { url: { anotherEntry: { repository: fakeRepository } } };
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    const result = await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0].data.metadata.repository).toBe(cheTheiaPluginMetaInfo.repository.url);
+  });
+
+  test('no package.json', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    delete Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+
+    await expect(cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos)).rejects.toThrow(
+      'No package.json found for'
+    );
+  });
+
+  test('no publisher field in package.json', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    if (packageJson) {
+      delete packageJson.publisher;
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+
+    await expect(cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos)).rejects.toThrow(
+      'No publisher field in package.json found for'
+    );
+  });
+
+  test('no name field in package.json', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    if (packageJson) {
+      delete packageJson.name;
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+
+    await expect(cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos)).rejects.toThrow(
+      'No name field in package.json found for'
+    );
+  });
+
+  test('no version field in package.json', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    if (packageJson) {
+      delete packageJson.version;
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+
+    await expect(cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos)).rejects.toThrow(
+      'No version field in package.json found for'
+    );
+  });
+
+  test('no icon field in package.json', async () => {
+    const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
+    if (packageJson) {
+      delete packageJson.icon;
+    }
+    const cheTheiaPluginMetaInfos: CheTheiaPluginMetaInfo[] = [cheTheiaPluginMetaInfo];
+    await cheTheiaPluginsYamlGenerator.compute(cheTheiaPluginMetaInfos);
+    expect(console.warn as jest.Mock).toBeCalled();
+    const call = (console.warn as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('No icon field in package.json found for');
+  });
+});

--- a/tools/build/tests/che-theia-plugin/che-theia-plugins-yaml-writer.spec.ts
+++ b/tools/build/tests/che-theia-plugin/che-theia-plugins-yaml-writer.spec.ts
@@ -1,0 +1,247 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+
+import { CheTheiaPluginYamlInfo } from '../../src/che-theia-plugin/che-theia-plugin-yaml-info';
+import { CheTheiaPluginsYamlWriter } from '../../src/che-theia-plugin/che-theia-plugins-yaml-writer';
+import { Container } from 'inversify';
+import { VsixInfo } from '../../src/extensions/vsix-info';
+
+describe('Test CheTheiaPluginsYamlWriter', () => {
+  let container: Container;
+
+  let cheTheiaPluginYaml: CheTheiaPluginYamlInfo;
+  let cheTheiaPluginsYamlWriter: CheTheiaPluginsYamlWriter;
+  let embedVsix = false;
+  const vsixInfos = new Map<string, VsixInfo>();
+
+  function initContainer() {
+    container = new Container();
+    container.bind('string').toConstantValue('/fake-output').whenTargetNamed('OUTPUT_ROOT_DIRECTORY');
+    container.bind('boolean').toConstantValue(embedVsix).whenTargetNamed('EMBED_VSIX');
+    container.bind(CheTheiaPluginsYamlWriter).toSelf().inSingletonScope();
+  }
+
+  beforeEach(() => {
+    vsixInfos.clear();
+
+    cheTheiaPluginYaml = {
+      aliases: ['first/alias', 'second/alias'],
+      vsixInfos,
+      data: {
+        schemaVersion: '1.0.0',
+        metadata: {
+          id: 'custom-publisher/custom-name',
+          publisher: 'my-publisher',
+          name: 'my-name',
+          version: 'latest',
+          displayName: 'display-name',
+          description: 'my-description',
+          iconFile: '/fake-dir/icon.png',
+          categories: ['Programming Languages'],
+          repository: 'http://fake-repository',
+        },
+        sidecar: {
+          image: 'foo',
+        },
+        preferences: {
+          'foo.bar': 'foo',
+        },
+        extensions: ['http://my-first.vsix'],
+      },
+    };
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    initContainer();
+    cheTheiaPluginsYamlWriter = container.get(CheTheiaPluginsYamlWriter);
+  });
+
+  test('basics', async () => {
+    const fsCopyFileSpy = jest.spyOn(fs, 'copyFile');
+    const fsEnsureDirSpy = jest.spyOn(fs, 'ensureDir');
+    const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
+
+    fsEnsureDirSpy.mockReturnValue();
+    fsCopyFileSpy.mockReturnValue();
+    fsWriteFileSpy.mockReturnValue();
+
+    const cheTheiaPlugins: CheTheiaPluginYamlInfo[] = [cheTheiaPluginYaml];
+    await cheTheiaPluginsYamlWriter.write(cheTheiaPlugins);
+
+    expect(fsCopyFileSpy).toHaveBeenCalledWith(
+      '/fake-dir/icon.png',
+      '/fake-output/v3/images/my-publisher-my-name-icon.png'
+    );
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(1, '/fake-output/v3/plugins');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(2, '/fake-output/v3/images');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(3, '/fake-output/v3/resources');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(4, '/fake-output/v3/plugins/custom-publisher/custom-name/latest');
+    const content = `schemaVersion: 1.0.0
+metadata:
+  id: custom-publisher/custom-name
+  publisher: custom-publisher
+  name: custom-name
+  version: latest
+  displayName: display-name
+  description: my-description
+  categories:
+    - Programming Languages
+  repository: 'http://fake-repository'
+  icon: /v3/images/my-publisher-my-name-icon.png
+sidecar:
+  image: foo
+preferences:
+  foo.bar: foo
+extensions:
+  - 'http://my-first.vsix'
+`;
+    expect(fsWriteFileSpy).toHaveBeenNthCalledWith(
+      1,
+      '/fake-output/v3/plugins/custom-publisher/custom-name/latest/che-theia-plugin.yaml',
+      content
+    );
+
+    // check that alias is also being written (and alias is deprecated)
+    const aliasContent = content.replace(/custom-publisher/g, 'first').replace(/custom-name/g, 'alias');
+    expect(fsWriteFileSpy).toHaveBeenNthCalledWith(
+      2,
+      '/fake-output/v3/plugins/first/alias/latest/che-theia-plugin.yaml',
+      aliasContent
+    );
+  });
+
+  test('default icon', async () => {
+    const fsCopyFileSpy = jest.spyOn(fs, 'copyFile');
+    const fsEnsureDirSpy = jest.spyOn(fs, 'ensureDir');
+    const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
+
+    fsEnsureDirSpy.mockReturnValue();
+    fsCopyFileSpy.mockReturnValue();
+    fsWriteFileSpy.mockReturnValue();
+    delete cheTheiaPluginYaml.data.metadata.iconFile;
+    delete cheTheiaPluginYaml.aliases;
+    const cheTheiaPlugins: CheTheiaPluginYamlInfo[] = [cheTheiaPluginYaml];
+    await cheTheiaPluginsYamlWriter.write(cheTheiaPlugins);
+    // no copy of the icon
+    expect(fsCopyFileSpy).toHaveBeenCalledTimes(0);
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(1, '/fake-output/v3/plugins');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(2, '/fake-output/v3/images');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(3, '/fake-output/v3/resources');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(4, '/fake-output/v3/plugins/custom-publisher/custom-name/latest');
+
+    // icon is the default one
+    const content = `schemaVersion: 1.0.0
+metadata:
+  id: custom-publisher/custom-name
+  publisher: custom-publisher
+  name: custom-name
+  version: latest
+  displayName: display-name
+  description: my-description
+  categories:
+    - Programming Languages
+  repository: 'http://fake-repository'
+  icon: /v3/images/eclipse-che-logo.png
+sidecar:
+  image: foo
+preferences:
+  foo.bar: foo
+extensions:
+  - 'http://my-first.vsix'
+`;
+
+    expect(fsWriteFileSpy).toHaveBeenNthCalledWith(
+      1,
+      '/fake-output/v3/plugins/custom-publisher/custom-name/latest/che-theia-plugin.yaml',
+      content
+    );
+    // no version written with disable Latest
+    expect(fsWriteFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('embed vsix', async () => {
+    embedVsix = true;
+    initContainer();
+    cheTheiaPluginsYamlWriter = container.get(CheTheiaPluginsYamlWriter);
+
+    const fsCopyFileSpy = jest.spyOn(fs, 'copyFile');
+    const fsEnsureDirSpy = jest.spyOn(fs, 'ensureDir');
+    const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
+
+    fsEnsureDirSpy.mockReturnValue();
+    fsCopyFileSpy.mockReturnValue();
+    fsWriteFileSpy.mockReturnValue();
+    delete cheTheiaPluginYaml.data.metadata.iconFile;
+    delete cheTheiaPluginYaml.aliases;
+
+    cheTheiaPluginYaml.data.extensions = [
+      'http://fake-domain.com/folder/my.vsix',
+      'https://other-fake-domain.com/subfolder/two.vsix',
+      'https://another-entry.com/folder3/three.vsix',
+    ];
+
+    const cheTheiaPlugins: CheTheiaPluginYamlInfo[] = [cheTheiaPluginYaml];
+
+    const downloadedArchive1 = '/fake-download-archive1.vsix';
+    const downloadedArchive2 = '/fake-download-archive2.vsix';
+    const firstVsixInfo: VsixInfo = {
+      downloadedArchive: downloadedArchive1,
+    } as VsixInfo;
+    const secondVsixInfo: VsixInfo = {
+      downloadedArchive: downloadedArchive2,
+    } as VsixInfo;
+    vsixInfos.set('http://fake-domain.com/folder/my.vsix', firstVsixInfo);
+    vsixInfos.set('https://other-fake-domain.com/subfolder/two.vsix', secondVsixInfo);
+
+    await cheTheiaPluginsYamlWriter.write(cheTheiaPlugins);
+    // no copy of the icon
+    expect(fsCopyFileSpy).toHaveBeenCalledTimes(2);
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(1, '/fake-output/v3/plugins');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(2, '/fake-output/v3/images');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(3, '/fake-output/v3/resources');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(4, '/fake-output/v3/resources/fake-domain_com/folder');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(5, '/fake-output/v3/resources/other-fake-domain_com/subfolder');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(6, '/fake-output/v3/plugins/custom-publisher/custom-name/latest');
+    expect(fsEnsureDirSpy).toHaveBeenNthCalledWith(6, '/fake-output/v3/plugins/custom-publisher/custom-name/latest');
+    // icon is the default one
+    const content = `schemaVersion: 1.0.0
+metadata:
+  id: custom-publisher/custom-name
+  publisher: custom-publisher
+  name: custom-name
+  version: latest
+  displayName: display-name
+  description: my-description
+  categories:
+    - Programming Languages
+  repository: 'http://fake-repository'
+  icon: /v3/images/eclipse-che-logo.png
+sidecar:
+  image: foo
+preferences:
+  foo.bar: foo
+extensions:
+  - 'relative:extension/resources/fake-domain_com/folder/my.vsix'
+  - 'relative:extension/resources/other-fake-domain_com/subfolder/two.vsix'
+  - 'https://another-entry.com/folder3/three.vsix'
+`;
+
+    expect(fsWriteFileSpy).toHaveBeenNthCalledWith(
+      1,
+      '/fake-output/v3/plugins/custom-publisher/custom-name/latest/che-theia-plugin.yaml',
+      content
+    );
+    // no version written with disable Latest
+    expect(fsWriteFileSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tools/build/tests/meta-yaml/index-writer.spec.ts
+++ b/tools/build/tests/meta-yaml/index-writer.spec.ts
@@ -52,6 +52,15 @@ describe('Test IndexWriter', () => {
         type: 'Che Editor',
         version: 'my-version',
       } as any,
+      {
+        description: 'my-unknown-desc',
+        displayName: 'unknown-display-name',
+        id: 'my-publisher/my-unknown-name/latest',
+        name: 'my-unknown-name',
+        publisher: 'my-unknown-publisher',
+        type: 'unknown',
+        version: 'my-version',
+      } as any,
     ];
     jest.restoreAllMocks();
     jest.resetAllMocks();
@@ -97,6 +106,7 @@ describe('Test IndexWriter', () => {
     expect(jsonOutput[2].id).toBe('my-publisher/my-name/latest');
     expect(jsonOutput[2].description).toBe('my-description');
     expect(jsonOutput[2].links.self).toBe('/v3/plugins/my-publisher/my-name/latest');
+    expect(jsonOutput[2].links.plugin).toBe('/v3/plugins/my-publisher/my-name/latest/che-theia-plugin.yaml');
     // no devfile generation for VS Code extensions
     expect(jsonOutput[2].links.devfile).toBeUndefined();
     expect(jsonOutput[2].name).toBe('my-name');


### PR DESCRIPTION
### What does this PR do?
meta.yaml has no field to describe preferences, it's not compliant with devfile 2.0 definition of containers, etc.
so, when generating yaml files from che-theia-plugins.yaml , here it generates `che-theia-plugin.yaml` file in addition to meta.yaml

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19545


### How to test this PR?
Launch the build or look at the PR result and browse index.json, you will see plugin entries for VS Code extensions and it will contain links to `che-theia-plugin.yaml` fragment that you can also look

example: https://pr-check-933-alpine-che-plugin-registry.surge.sh/v3/plugins/redhat/java11/latest/che-theia-plugin.yaml


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I5718fde84620934c15764aa1edcbbea9e42eda70
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
