### PR TITLE
fix(entrypoint): Fix image regexp when using CHE_SIDECAR_CONTAINERS_REGISTRY_URL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,6 +90,9 @@ echo "Generate artifacts..."
 eval yarn node "${NODE_BUILD_OPTIONS}" lib/entrypoint.js --output-folder:"${base_dir}/output" ${BUILD_FLAGS}
 popd > /dev/null
 
+echo "Test entrypoint.sh"
+"${base_dir}"/build/dockerfiles/test_entrypoint.sh
+
 if [ "${SKIP_OCI_IMAGE}" != "true" ]; then
     BUILD_COMMAND="build"
     if [[ -z $BUILDER ]]; then

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ echo "Generate artifacts..."
 eval yarn node "${NODE_BUILD_OPTIONS}" lib/entrypoint.js --output-folder:"${base_dir}/output" ${BUILD_FLAGS}
 popd > /dev/null
 
-echo "Test entrypoint.sh"
+echo -e "\nTest entrypoint.sh"
 "${base_dir}"/build/dockerfiles/test_entrypoint.sh
 
 if [ "${SKIP_OCI_IMAGE}" != "true" ]; then

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@
 
 # Build registry
 FROM docker.io/httpd:2.4.46-alpine
-RUN apk add --no-cache bash && \
+RUN apk add --no-cache bash yq && \
     # Allow htaccess
     sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
     sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@
 
 # Build registry
 FROM docker.io/httpd:2.4.46-alpine
-RUN apk add --no-cache bash yq && \
+RUN apk add --no-cache bash && \
     # Allow htaccess
     sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
     sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -37,31 +37,6 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \7 - Optional quotation following image reference
 IMAGE_REGEX="([[:space:]>-]*[\r]?[[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 
-function update_container_image_references() {
-
-    # We can't use the `-d` option for readarray because
-    # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
-    # The below command will fail if any path contains whitespace
-    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
-    for meta in "${metas[@]}"; do
-    echo "Checking meta $meta"
-    # Need to update each field separately in case they are not defined.
-    # Defaults don't work because registry and tags may be different.
-    if [ -n "$REGISTRY" ]; then
-        echo "    Updating image registry to $REGISTRY"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
-    fi
-    if [ -n "$ORGANIZATION" ]; then
-        echo "    Updating image organization to $ORGANIZATION"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
-    fi
-    if [ -n "$TAG" ]; then
-        echo "    Updating image tag to $TAG"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
-    fi
-    done
-
-}
 
 function run_main() {
     # Extract and use env variables with image digest information.
@@ -133,6 +108,32 @@ function run_main() {
     update_container_image_references
 
     exec "${@}"
+
+}
+
+function update_container_image_references() {
+
+    # We can't use the `-d` option for readarray because
+    # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
+    # The below command will fail if any path contains whitespace
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+    for meta in "${metas[@]}"; do
+    echo "Checking meta $meta"
+    # Need to update each field separately in case they are not defined.
+    # Defaults don't work because registry and tags may be different.
+    if [ -n "$REGISTRY" ]; then
+        echo "    Updating image registry to $REGISTRY"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+    fi
+    if [ -n "$ORGANIZATION" ]; then
+        echo "    Updating image organization to $ORGANIZATION"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+    fi
+    if [ -n "$TAG" ]; then
+        echo "    Updating image tag to $TAG"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+    fi
+    done
 
 }
 

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -37,92 +37,107 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \7 - Optional quotation following image reference
 IMAGE_REGEX="([[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 
-# Extract and use env variables with image digest information.
-# Env variable name format: 
-# RELATED_IMAGES_(Image_name)_(Image_label)_(Encoded_base32_image_tag)
-# Where are:
-# "Image_name" - image name. Not valid chars for env variable name replaced to '_'.
-# "Image_label" - image target, for example 'plugin_registry_image'.
-# "Encoded_base32_image_tag_" - original image tag encoded to base32, to avoid invalid for env name chars. base32 alphabet has only 
-# one invalid character for env name: '='. That's why it was replaced to '_'. 
-# INFO: "=" for base32 it is pad character. If encoded string contains this char(s), then it is always located at the end of the string.
-# Env value it is image with digest to use.
-# Example env variable:
-# RELATED_IMAGE_che_sidecar_clang_plugin_registry_image_HAWTQM3BMRRDGYIK="quay.io/eclipse/che-sidecar-clang@sha256:1c217f34ca69108fdd1ab844c0bcf960edff92519677bde4f8a5f4841b104745"
-if env | grep -q ".*plugin_registry_image.*"; then
-  declare -A imageMap
-  readarray -t ENV_IMAGES < <(env | grep ".*plugin_registry_image.*")
-  for imageEnv in "${ENV_IMAGES[@]}"; do
-    tagOrDigest=$(echo "${imageEnv}" | sed -e 's;.*registry_image_\(.*\)=.*;\1;' | tr _ = | base32 -d)
-    if [[ ${tagOrDigest} == *"@"* ]]; then
-      # Well, image was "freezed", because it already has got digest, so do nothing.
-      continue
+function update_container_image_references() {
+
+    # We can't use the `-d` option for readarray because
+    # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
+    # The below command will fail if any path contains whitespace
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+    for meta in "${metas[@]}"; do
+    echo "Checking meta $meta"
+    # Need to update each field separately in case they are not defined.
+    # Defaults don't work because registry and tags may be different.
+    if [ -n "$REGISTRY" ]; then
+        echo "    Updating image registry to $REGISTRY"
+        sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
     fi
-    imageWithDigest=${imageEnv#*=};
-    if [[ -n "${tagOrDigest}" ]]; then
-      imageToReplace="${imageWithDigest%@*}:${tagOrDigest}"
-    else
-      imageToReplace="${imageWithDigest%@*}"
+    if [ -n "$ORGANIZATION" ]; then
+        echo "    Updating image organization to $ORGANIZATION"
+        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
     fi
-    digest="@${imageWithDigest#*@}"
-    imageMap["${imageToReplace}"]="${digest}"
-  done
+    if [ -n "$TAG" ]; then
+        echo "    Updating image tag to $TAG"
+        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
+    fi
+    done
 
-  echo "--------------------------Digest map--------------------------"
-  for KEY in "${!imageMap[@]}"; do
-    echo "Key: $KEY Value: ${imageMap[${KEY}]}"
-  done
-  echo "--------------------------------------------------------------"
+}
 
-  readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
-  for meta in "${metas[@]}"; do
-    readarray -t images < <(grep "image:" "${meta}" | sed -r "s;.*image:[[:space:]]*'?\"?([._:a-zA-Z0-9-]*/?[._a-zA-Z0-9-]*/[._a-zA-Z0-9-]*(@sha256)?:?[._a-zA-Z0-9-]*)'?\"?[[:space:]]*;\1;")
-    for image in "${images[@]}"; do
-      separators="${image//[^\/]}"
-      # Warning, keep in mind: image without registry name is it possible case. It's mean, that image comes from private registry, where is we have organization name, but no registry name...
-      digest="${imageMap[${image}]}"
-
-      if [[ -z "${digest}" ]] && [ "${#separators}" == "1" ]; then
-        imageWithDefaultRegistry="docker.io/${image}"
-        digest="${imageMap[${imageWithDefaultRegistry}]}"
-      fi
-
-      if [[ -n "${digest}" ]]; then
-        if [[ ${image} == *":"* ]]; then
-          imageWithoutTag="${image%:*}"
-          tag="${image#*:}"
+function run_main() {
+    # Extract and use env variables with image digest information.
+    # Env variable name format: 
+    # RELATED_IMAGES_(Image_name)_(Image_label)_(Encoded_base32_image_tag)
+    # Where are:
+    # "Image_name" - image name. Not valid chars for env variable name replaced to '_'.
+    # "Image_label" - image target, for example 'plugin_registry_image'.
+    # "Encoded_base32_image_tag_" - original image tag encoded to base32, to avoid invalid for env name chars. base32 alphabet has only 
+    # one invalid character for env name: '='. That's why it was replaced to '_'. 
+    # INFO: "=" for base32 it is pad character. If encoded string contains this char(s), then it is always located at the end of the string.
+    # Env value it is image with digest to use.
+    # Example env variable:
+    # RELATED_IMAGE_che_sidecar_clang_plugin_registry_image_HAWTQM3BMRRDGYIK="quay.io/eclipse/che-sidecar-clang@sha256:1c217f34ca69108fdd1ab844c0bcf960edff92519677bde4f8a5f4841b104745"
+    if env | grep -q ".*plugin_registry_image.*"; then
+    declare -A imageMap
+    readarray -t ENV_IMAGES < <(env | grep ".*plugin_registry_image.*")
+    for imageEnv in "${ENV_IMAGES[@]}"; do
+        tagOrDigest=$(echo "${imageEnv}" | sed -e 's;.*registry_image_\(.*\)=.*;\1;' | tr _ = | base32 -d)
+        if [[ ${tagOrDigest} == *"@"* ]]; then
+        # Well, image was "freezed", because it already has got digest, so do nothing.
+        continue
+        fi
+        imageWithDigest=${imageEnv#*=};
+        if [[ -n "${tagOrDigest}" ]]; then
+        imageToReplace="${imageWithDigest%@*}:${tagOrDigest}"
         else
-          imageWithoutTag=${image}
-          tag=""
+        imageToReplace="${imageWithDigest%@*}"
+        fi
+        digest="@${imageWithDigest#*@}"
+        imageMap["${imageToReplace}"]="${digest}"
+    done
+
+    echo "--------------------------Digest map--------------------------"
+    for KEY in "${!imageMap[@]}"; do
+        echo "Key: $KEY Value: ${imageMap[${KEY}]}"
+    done
+    echo "--------------------------------------------------------------"
+
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+    for meta in "${metas[@]}"; do
+        readarray -t images < <(grep "image:" "${meta}" | sed -r "s;.*image:[[:space:]]*'?\"?([._:a-zA-Z0-9-]*/?[._a-zA-Z0-9-]*/[._a-zA-Z0-9-]*(@sha256)?:?[._a-zA-Z0-9-]*)'?\"?[[:space:]]*;\1;")
+        for image in "${images[@]}"; do
+        separators="${image//[^\/]}"
+        # Warning, keep in mind: image without registry name is it possible case. It's mean, that image comes from private registry, where is we have organization name, but no registry name...
+        digest="${imageMap[${image}]}"
+
+        if [[ -z "${digest}" ]] && [ "${#separators}" == "1" ]; then
+            imageWithDefaultRegistry="docker.io/${image}"
+            digest="${imageMap[${imageWithDefaultRegistry}]}"
         fi
 
-        REGEX="([[:space:]]*\"?'?)(${imageWithoutTag}):?(${tag})(\"?'?)"
-        sed -i -E "s|image:${REGEX}|image:\1\2${digest}\4|" "$meta"
-      fi
+        if [[ -n "${digest}" ]]; then
+            if [[ ${image} == *":"* ]]; then
+            imageWithoutTag="${image%:*}"
+            tag="${image#*:}"
+            else
+            imageWithoutTag=${image}
+            tag=""
+            fi
+
+            REGEX="([[:space:]]*\"?'?)(${imageWithoutTag}):?(${tag})(\"?'?)"
+            sed -i -E "s|image:${REGEX}|image:\1\2${digest}\4|" "$meta"
+        fi
+        done
     done
-  done
+    fi
+
+    update_container_image_references
+
+    exec "${@}"
+
+}
+
+# do not execute the main function in unit tests
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+    run_main
 fi
-
-# We can't use the `-d` option for readarray because
-# registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
-# The below command will fail if any path contains whitespace
-readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
-for meta in "${metas[@]}"; do
-  echo "Checking meta $meta"
-  # Need to update each field separately in case they are not defined.
-  # Defaults don't work because registry and tags may be different.
-  if [ -n "$REGISTRY" ]; then
-    echo "    Updating image registry to $REGISTRY"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
-  fi
-  if [ -n "$ORGANIZATION" ]; then
-    echo "    Updating image organization to $ORGANIZATION"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
-  fi
-  if [ -n "$TAG" ]; then
-    echo "    Updating image tag to $TAG"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
-  fi
-done
-
-exec "${@}"

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -123,15 +123,15 @@ function update_container_image_references() {
     # Defaults don't work because registry and tags may be different.
     if [ -n "$REGISTRY" ]; then
         echo "    Updating image registry to $REGISTRY"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$ORGANIZATION" ]; then
         echo "    Updating image organization to $ORGANIZATION"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$TAG" ]; then
         echo "    Updating image tag to $TAG"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     done
 

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -35,7 +35,7 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
 #   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
 #   \7 - Optional quotation following image reference
-IMAGE_REGEX="([[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
+IMAGE_REGEX="([[:space:]>-]*[\r]?[[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 
 function update_container_image_references() {
 
@@ -49,15 +49,15 @@ function update_container_image_references() {
     # Defaults don't work because registry and tags may be different.
     if [ -n "$REGISTRY" ]; then
         echo "    Updating image registry to $REGISTRY"
-        sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
+        cat "$meta" | tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$ORGANIZATION" ]; then
         echo "    Updating image organization to $ORGANIZATION"
-        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
+        cat "$meta" | tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$TAG" ]; then
         echo "    Updating image tag to $TAG"
-        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
+        cat "$meta" | tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     done
 

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -35,7 +35,7 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
 #   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
 #   \7 - Optional quotation following image reference
-IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)("?)'
+IMAGE_REGEX="([[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 
 # Extract and use env variables with image digest information.
 # Env variable name format: 

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -49,15 +49,15 @@ function update_container_image_references() {
     # Defaults don't work because registry and tags may be different.
     if [ -n "$REGISTRY" ]; then
         echo "    Updating image registry to $REGISTRY"
-        cat "$meta" | tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$ORGANIZATION" ]; then
         echo "    Updating image organization to $ORGANIZATION"
-        cat "$meta" | tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$TAG" ]; then
         echo "    Updating image tag to $TAG"
-        cat "$meta" | tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     done
 
@@ -139,5 +139,5 @@ function run_main() {
 # do not execute the main function in unit tests
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
 then
-    run_main
+    run_main "${@}"
 fi

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -28,12 +28,14 @@ DEFAULT_METAS_DIR="/var/www/html/v3"
 METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 
 # Regex used to break an image reference into groups:
-#   \1 - Registry portion of image, e.g. (quay.io)/eclipse/che-theia:tag
-#   \2 - Organization portion of image, e.g. quay.io/(eclipse)/che-theia:tag
-#   \3 - Image name portion of image, e.g. quay.io/eclipse/(che-theia):tag
-#   \4 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
-#   \5 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
-IMAGE_REGEX="([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)"
+#   \1 - Whitespace and (optional) quotation preceding image reference
+#   \2 - Registry portion of image, e.g. (quay.io)/eclipse/che-theia:tag
+#   \3 - Organization portion of image, e.g. quay.io/(eclipse)/che-theia:tag
+#   \4 - Image name portion of image, e.g. quay.io/eclipse/(che-theia):tag
+#   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
+#   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
+#   \7 - Optional quotation following image reference
+IMAGE_REGEX="([[:space:]>-]*[\r]?[[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 
 
 function run_main() {
@@ -121,24 +123,15 @@ function update_container_image_references() {
     # Defaults don't work because registry and tags may be different.
     if [ -n "$REGISTRY" ]; then
         echo "    Updating image registry to $REGISTRY"
-        for ypath in $(yq r --printMode p "${meta}" '**.image'); do
-            newvalue=$(yq r "${meta}" "$ypath" | sed -E "s|$IMAGE_REGEX|${REGISTRY}/\2/\3\4:\5|")
-            yq w -i "$meta" "$ypath" "$newvalue"
-        done
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$ORGANIZATION" ]; then
         echo "    Updating image organization to $ORGANIZATION"
-        for ypath in $(yq r --printMode p "${meta}" '**.image'); do
-            newvalue=$(yq r "${meta}" "$ypath" | sed -E "s|$IMAGE_REGEX|\1/${ORGANIZATION}/\3\4:\5|")
-            yq w -i "$meta" "$ypath" "$newvalue"
-        done
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$TAG" ]; then
         echo "    Updating image tag to $TAG"
-        for ypath in $(yq r --printMode p "${meta}" '**.image'); do
-            newvalue=$(yq r "${meta}" "$ypath" | sed -E "s|$IMAGE_REGEX|\1/\2/\3:${TAG}|")
-            yq w -i "$meta" "$ypath" "$newvalue"
-        done
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     done
 

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -55,18 +55,17 @@ END
 expected_metayaml=$(cat <<-END
 spec:
   containers:
-    - image: 'https://fakeregistry.io:9000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+    - image: 'https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
       name: asciidoctor-vscode
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:9000'
+CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
 
 assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
-
 
 #################################################################
 echo -e "\n## Should update image registry URL. Double quote."
@@ -81,19 +80,44 @@ END
 expected_metayaml=$(cat <<-END
 spec:
   containers:
-    - image: "https://fakeregistry.io:9000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d"
+    - image: "https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d"
       name: asciidoctor-vscode
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:9000'
+CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
 
 assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+#################################################################
+echo -e "\n## Should update image registry URL. Multiline."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+source "${script_dir}/entrypoint.sh"
 
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
 echo -e "\n## Should update image organization."
@@ -120,6 +144,32 @@ update_container_image_references
 
 assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+#################################################################
+echo -e "\n## Should update image organization. Multiline."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/fakeorg/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
 echo -e "\n## Should update image tag."
@@ -135,6 +185,33 @@ expected_metayaml=$(cat <<-END
 spec:
   containers:
     - image: 'quay.io/eclipse/che-plugin-sidecar:faketag'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+#################################################################
+echo -e "\n## Should update image tag. Multiline."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar:faketag
       name: asciidoctor-vscode
 END
 )

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -10,7 +10,7 @@
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-METAS_DIR=`mktemp -d`
+METAS_DIR=$(mktemp -d)
 
 function cleanup() {
     rm -rf  "${METAS_DIR}";
@@ -18,7 +18,7 @@ function cleanup() {
 trap cleanup EXIT
 
 function beforeTest() {
-    rm -rf "${METAS_DIR}"/*
+    rm -rf "${METAS_DIR:?}"/*
     unset CHE_SIDECAR_CONTAINERS_REGISTRY_URL \
           CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION \
           CHE_SIDECAR_CONTAINERS_REGISTRY_TAG
@@ -60,7 +60,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
@@ -85,7 +86,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
@@ -112,7 +114,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
@@ -137,7 +140,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
@@ -164,7 +168,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
@@ -189,7 +194,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references
@@ -216,7 +222,8 @@ spec:
 END
 )
 echo "$metayaml" > "${METAS_DIR}/meta.yaml"
-CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+export CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+# shellcheck disable=SC1090
 source "${script_dir}/entrypoint.sh"
 
 update_container_image_references

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+METAS_DIR=`mktemp -d`
+
+function cleanup() {
+    rm -rf  "${METAS_DIR}";
+}
+trap cleanup EXIT
+
+function beforeTest() {
+    rm -rf "${METAS_DIR}"/*
+    unset CHE_SIDECAR_CONTAINERS_REGISTRY_URL \
+          CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION \
+          CHE_SIDECAR_CONTAINERS_REGISTRY_TAG
+
+}
+
+function assertFileContains() {
+    file=$1
+    expected_metayaml=$2
+    if [[ $(cat "${file}") == "${expected_metayaml}" ]]; then
+        echo "Test passed!"
+    else
+        echo "Test failed!"
+        echo "Result:"
+        cat "${file}"
+        echo "Expected:"
+        echo "${expected_metayaml}"
+        exit 1
+    fi
+}
+
+echo "# ${BASH_SOURCE[0]} Running tests for entrypoint.sh"
+
+#################################################################
+echo -e "\n## Should update image registry URL. Simple quote."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'https://fakeregistry.io:9000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:9000'
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+echo -e "\n## Should update image registry URL. Double quote."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: "quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d"
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: "https://fakeregistry.io:9000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d"
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:9000'
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+
+#################################################################
+echo -e "\n## Should update image organization."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/fakeorg/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+echo -e "\n## Should update image tag."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar:faketag'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -21,9 +21,15 @@ RED="\e[31m"
 GREEN="\e[32m"
 RESETSTYLE="\e[0m"
 BOLD="\e[1m"
+DEFAULT_EMOJI_HEADER="🏃" # could be overiden with EMOJI_HEADER="-"
+EMOJI_HEADER=${EMOJI_HEADER:-$DEFAULT_EMOJI_HEADER}
+DEFAULT_EMOJI_PASS="✔" # could be overriden with EMOJI_PASS="[PASS]"
+EMOJI_PASS=${EMOJI_PASS:-$DEFAULT_EMOJI_PASS}
+DEFAULT_EMOJI_FAIL="✘" # could be overriden with EMOJI_FAIL="[FAIL]"
+EMOJI_FAIL=${EMOJI_FAIL:-$DEFAULT_EMOJI_FAIL}
 
 function initTest() {
-    echo -e "${BOLD}\n🏃 ${1}${RESETSTYLE}"
+    echo -e "${BOLD}\n${EMOJI_HEADER} ${1}${RESETSTYLE}"
     rm -rf "${METAS_DIR:?}"/*
     unset CHE_SIDECAR_CONTAINERS_REGISTRY_URL \
           CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION \
@@ -36,9 +42,9 @@ function assertFileContentEquals() {
     expected_metayaml=$2
 
     if [[ $(cat "${file}") == "${expected_metayaml}" ]]; then
-        echo -e "${GREEN}✔${RESETSTYLE} Test passed!"
+        echo -e "${GREEN}${EMOJI_PASS}${RESETSTYLE} Test passed!"
     else
-        echo -e "${RED}✘${RESETSTYLE} Test failed!"
+        echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
         echo "Result:"
         cat "${file}"
         echo "Expected:"
@@ -46,7 +52,7 @@ function assertFileContentEquals() {
         exit 1
     fi
 }
-echo -e "${BOLD}\n🏃🏃🏃 Running tests for entrypoint.sh: ${BASH_SOURCE[0]}${RESETSTYLE}"
+echo -e "${BOLD}\n${EMOJI_HEADER}${EMOJI_HEADER}${EMOJI_HEADER} Running tests for entrypoint.sh: ${BASH_SOURCE[0]}${RESETSTYLE}"
 
 
 #################################################################

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -74,7 +74,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL. Double quote.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Double quote.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -100,7 +100,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL. Multiline.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiline.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -129,7 +129,7 @@ assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL. Multiple occurences.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiple occurences.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -209,7 +209,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image organization.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -235,7 +235,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image organization. Multiline.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION. Multiline.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -263,7 +263,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image tag.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -289,7 +289,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image tag. Multiline.${RESETSTYLE}"
+echo -e "${BOLD}\n🏃 Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG. Multiline.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -25,13 +25,19 @@ function beforeTest() {
 
 }
 
+RED="\e[31m"
+GREEN="\e[32m"
+RESETSTYLE="\e[0m"
+BOLD="\e[1m"
+
 function assertFileContentEquals() {
     file=$1
     expected_metayaml=$2
+
     if [[ $(cat "${file}") == "${expected_metayaml}" ]]; then
-        echo "Test passed!"
+        echo -e "${GREEN}✔${RESETSTYLE} Test passed!"
     else
-        echo "Test failed!"
+        echo -e "${RED}✘${RESETSTYLE} Test failed!"
         echo "Result:"
         cat "${file}"
         echo "Expected:"
@@ -39,11 +45,10 @@ function assertFileContentEquals() {
         exit 1
     fi
 }
-
-echo "# ${BASH_SOURCE[0]} Running tests for entrypoint.sh"
+echo -e "${BOLD}\n🏃🏃🏃 Running tests for entrypoint.sh: ${BASH_SOURCE[0]}${RESETSTYLE}"
 
 #################################################################
-echo -e "\n## Should update image registry URL. Simple quote."
+echo -e "${BOLD}\n🏃 Should update image registry URL. Simple quote.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -69,7 +74,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should update image registry URL. Double quote."
+echo -e "${BOLD}\n🏃 Should update image registry URL. Double quote.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -95,7 +100,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should update image registry URL. Multiline."
+echo -e "${BOLD}\n🏃 Should update image registry URL. Multiline.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -124,7 +129,7 @@ assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 
 #################################################################
-echo -e "\n## Should update image registry URL. Multiple occurences."
+echo -e "${BOLD}\n🏃 Should update image registry URL. Multiple occurences.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -204,7 +209,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should update image organization."
+echo -e "${BOLD}\n🏃 Should update image organization.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -230,7 +235,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should update image organization. Multiline."
+echo -e "${BOLD}\n🏃 Should update image organization. Multiline.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -258,7 +263,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should update image tag."
+echo -e "${BOLD}\n🏃 Should update image tag.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -284,7 +289,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should update image tag. Multiline."
+echo -e "${BOLD}\n🏃 Should update image tag. Multiline.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:
@@ -312,7 +317,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "\n## Should do nothing."
+echo -e "${BOLD}\n🏃 Should do nothing.${RESETSTYLE}"
 beforeTest
 metayaml=$(cat <<-END
 spec:

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -122,6 +122,87 @@ update_container_image_references
 
 assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
+#################################################################
+echo -e "\n## Should update image registry URL. Multiple occurences."
+beforeTest
+metayaml=$(cat <<-END
+spec:
+ containers:
+    - image: 'quay.io/eclipse/che-theia@sha256:69b7d27a9e9a4b46c2734d995456385bb0d7ab1022638d95ddaa5a5919ef43c1'
+      env:
+        - name: THEIA_PLUGINS
+          value: 'local-dir:///plugins'
+        - name: HOSTED_PLUGIN_HOSTNAME
+          value: 0.0.0.0
+        - name: HOSTED_PLUGIN_PORT
+          value: '3130'
+        - name: THEIA_HOST
+          value: 127.0.0.1
+      mountSources: true
+      memoryLimit: 512M
+      volumes:
+        - name: plugins
+          mountPath: /plugins
+        - name: theia-local
+          mountPath: /home/theia/.theia
+      name: theia-ide
+      ports:
+        - exposedPort: 3100
+        - exposedPort: 3130
+        - exposedPort: 13131
+        - exposedPort: 13132
+        - exposedPort: 13133
+    - image: 'quay.io/eclipse/che-machine-exec@sha256:98fdc3f341ed683dc0f07176729c887f2b965bade9c27d16dc0e05f9034e624c'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '127.0.0.1:3333'
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+ containers:
+    - image: 'https://fakeregistry.io:5000/eclipse/che-theia@sha256:69b7d27a9e9a4b46c2734d995456385bb0d7ab1022638d95ddaa5a5919ef43c1'
+      env:
+        - name: THEIA_PLUGINS
+          value: 'local-dir:///plugins'
+        - name: HOSTED_PLUGIN_HOSTNAME
+          value: 0.0.0.0
+        - name: HOSTED_PLUGIN_PORT
+          value: '3130'
+        - name: THEIA_HOST
+          value: 127.0.0.1
+      mountSources: true
+      memoryLimit: 512M
+      volumes:
+        - name: plugins
+          mountPath: /plugins
+        - name: theia-local
+          mountPath: /home/theia/.theia
+      name: theia-ide
+      ports:
+        - exposedPort: 3100
+        - exposedPort: 3130
+        - exposedPort: 13131
+        - exposedPort: 13132
+        - exposedPort: 13133
+    - image: 'https://fakeregistry.io:5000/eclipse/che-machine-exec@sha256:98fdc3f341ed683dc0f07176729c887f2b965bade9c27d16dc0e05f9034e624c'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '127.0.0.1:3333'
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContains "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
 #################################################################
 echo -e "\n## Should update image organization."
 beforeTest

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -17,18 +17,19 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-function beforeTest() {
+RED="\e[31m"
+GREEN="\e[32m"
+RESETSTYLE="\e[0m"
+BOLD="\e[1m"
+
+function initTest() {
+    echo -e "${BOLD}\n🏃 ${1}${RESETSTYLE}"
     rm -rf "${METAS_DIR:?}"/*
     unset CHE_SIDECAR_CONTAINERS_REGISTRY_URL \
           CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION \
           CHE_SIDECAR_CONTAINERS_REGISTRY_TAG
 
 }
-
-RED="\e[31m"
-GREEN="\e[32m"
-RESETSTYLE="\e[0m"
-BOLD="\e[1m"
 
 function assertFileContentEquals() {
     file=$1
@@ -47,9 +48,10 @@ function assertFileContentEquals() {
 }
 echo -e "${BOLD}\n🏃🏃🏃 Running tests for entrypoint.sh: ${BASH_SOURCE[0]}${RESETSTYLE}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL. Simple quote.${RESETSTYLE}"
-beforeTest
+initTest "Should update image registry URL. Simple quote."
+
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -73,9 +75,10 @@ update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Double quote.${RESETSTYLE}"
-beforeTest
+initTest "Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Double quote."
+
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -99,9 +102,10 @@ update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiline.${RESETSTYLE}"
-beforeTest
+initTest "Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiline."
+
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -129,8 +133,8 @@ assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiple occurences.${RESETSTYLE}"
-beforeTest
+initTest "Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiple occurences."
+
 metayaml=$(cat <<-END
 spec:
  containers:
@@ -209,8 +213,7 @@ update_container_image_references
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION.${RESETSTYLE}"
-beforeTest
+initTest "Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION."
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -234,9 +237,10 @@ update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION. Multiline.${RESETSTYLE}"
-beforeTest
+initTest "Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION. Multiline."
+
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -262,9 +266,10 @@ update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG.${RESETSTYLE}"
-beforeTest
+initTest "Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG."
+
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -288,9 +293,10 @@ update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG. Multiline.${RESETSTYLE}"
-beforeTest
+initTest "Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG. Multiline."
+
 metayaml=$(cat <<-END
 spec:
   containers:
@@ -316,9 +322,10 @@ update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
 
+
 #################################################################
-echo -e "${BOLD}\n🏃 Should do nothing.${RESETSTYLE}"
-beforeTest
+initTest "Should do nothing."
+
 metayaml=$(cat <<-END
 spec:
   containers:

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -28,12 +28,14 @@ function beforeTest() {
 function assertFileContentEquals() {
     file=$1
     expected_metayaml=$2
-    if [[ $(< "${file}" yq r --prettyPrint -) == $(echo "${expected_metayaml}" | yq r --prettyPrint -) ]]; then
+    if [[ $(cat "${file}") == "${expected_metayaml}" ]]; then
         echo "Test passed!"
     else
         echo "Test failed!"
-        echo "Diff result and expected:"
-        echo "${expected_metayaml}" | yq compare --prettyPrint "${file}" -
+        echo "Result:"
+        cat "${file}"
+        echo "Expected:"
+        echo "${expected_metayaml}"
         exit 1
     fi
 }

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -80,3 +80,10 @@ commands:
           done
           surge ./ ${CHE_WORKSPACE_NAMESPACE}-${CHE_WORKSPACE_NAME}.surge.sh && echo Checkout the published plugin registry at https://${CHE_WORKSPACE_NAMESPACE}-${CHE_WORKSPACE_NAME}.surge.sh/v3/plugins/
         component: builder
+
+  - name: test entrypoint.sh
+    actions:
+      - workdir: '${CHE_PROJECTS_ROOT}/che-plugin-registry/build/dockerfiles'
+        type: exec
+        command: ./test_entrypoint.sh
+        component: eclipse-che-plugin-registry


### PR DESCRIPTION
### What does this PR do?
1. Fix problems with image regexp:
   - single quotes not supported
   - multiline not supported
   - multiple occurence
2. Adding unit tests script

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19405 and https://github.com/eclipse/che/issues/19492

### How to test this PR?
1. Build the registry from this branch:
   ```
   ./build.sh
   ```
3. run the built container and check that  meta.yaml generated are OK, for instance `/var/www/html/v3/plugins/ms-python/python/latest/meta.yaml`
   ```
   podman run -t quay.io/eclipse/che-plugin-registry:nightly cat /var/www/html/v3/plugins/ms-python/python/latest/meta.yaml
   ```
   should contain these lines
    ```yaml
      - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:64311210e710ca1614839f897285fc1d39b2ca17215d56c165d091aafd19a14b'
   ```
4. check that meta.yaml works well with the env variable `CHE_SIDECAR_CONTAINERS_REGISTRY_URL`
   ```
   podman run -e CHE_SIDECAR_CONTAINERS_REGISTRY_URL=https://fakeregistry.io:5000 -t quay.io/eclipse/che-plugin-registry:nightly cat /var/www/html/v3/plugins/ms-python/python/latest/meta.yaml
   ```
   should contain these lines
    ```yaml
    - image: 'https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:64311210e710ca1614839f897285fc1d39b2ca17215d56c165d091aafd19a14b'
   ```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

