### PR TITLE
chore(sidecar): Ensure short sha1 for sidecar is 7 digits long

### DIFF
--- a/.ci/sidecar-build-publish.sh
+++ b/.ci/sidecar-build-publish.sh
@@ -24,7 +24,7 @@ do
         if ! [[ " ${SIDECARS_TO_TEST[@]} " =~ ${SIDECAR_NAME} ]]; then
             SIDECARS_TO_TEST+=("$SIDECAR_NAME")
             PLATFORMS=$(cat sidecars/"$SIDECAR_NAME"/PLATFORMS)
-            SHORT_SHA1=$(git rev-parse --short HEAD)
+            SHORT_SHA1=$(git rev-parse --short=7 HEAD)
             if [[ $BUILD_PUBLISH == 'build-publish' ]]; then
                 IMAGE_NAME=quay.io/eclipse/che-plugin-sidecar:"$SIDECAR_NAME"-"$SHORT_SHA1"
                 echo "Building $IMAGE_NAME"


### PR DESCRIPTION
### What does this PR do?
Ensure short sha1 for sidecar is 7 digits long
last time it was 8 digits (camelk-2eb28e46 instead of camelk-2eb28e4)


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
PR checks were failing


### How to test this PR?
```bash
$  git rev-parse --short HEAD
12e5943e
```

```bash
$ git rev-parse --short=7 HEAD
12e5943
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I79ceba176120a87801bb4a1d12e9d1e217927448
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
