### PR TITLE
fix(build): offline links were not added on dependencies of an extension

### DIFF
--- a/tools/build/src/che-theia-plugin/che-theia-plugins-meta-yaml-generator.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugins-meta-yaml-generator.ts
@@ -206,6 +206,7 @@ export class CheTheiaPluginsMetaYamlGenerator {
         const skipDependencies = chePlugin.skipDependencies || [];
         const extraDependencies = chePlugin.extraDependencies || [];
         let skipIndex = false;
+        const vsixInfos = new Map(chePlugin.vsixInfos);
 
         if (chePlugin.metaYaml) {
           // extra dependencies ?
@@ -238,13 +239,17 @@ export class CheTheiaPluginsMetaYamlGenerator {
             }
             // add the extension there
             resolvedExtensions.push(dependencyMeta.extension);
+
+            // add vsixInfos from that dependency
+            dependencyMeta.vsixInfos.forEach((value, key) => {
+              if (!vsixInfos.has(key)) {
+                vsixInfos.set(key, value);
+              }
+            });
           });
         }
 
         spec.extensions = resolvedExtensions;
-
-        // grab vsix infos
-        const vsixInfos = chePlugin.vsixInfos;
 
         const aliases = chePlugin.aliases;
 


### PR DESCRIPTION
### What does this PR do?
Due to missing metadata in dependencies, generated links were missing the relative part for dependencies

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19746


### How to test this PR?
build with `--offline` flag or use `yarn node lib/entrypoint.js --embed-vsix:true`

generated `v3/plugins/redhat/java/latest/meta.yaml` should contain `relative:extension` on all extensions

```yaml
    - 'relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix'
    - 'relative:extension/resources/download_jboss_org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix'
    - 'relative:extension/resources/open-vsx_org/api/vscjava/vscode-java-test/0_28_1/file/vscjava.vscode-java-test-0.28.1.vsix'
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I9e9e19b9d698515bca9eb63121ed6dbb01d1a4a8
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
