### PR TITLE
feat(python-jupyter): Setting up venv in a dedicated volume

### DIFF
--- a/sidecars/python/Dockerfile
+++ b/sidecars/python/Dockerfile
@@ -12,13 +12,6 @@ FROM python:3.8.6-slim
 
 ENV HOME=/home/theia
 
-RUN mkdir /projects ${HOME} && \
-    # Change permissions to let any arbitrary user
-    for f in "${HOME}" "/etc/passwd" "/projects"; do \
-      echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
-      chmod -R g+rwX ${f}; \
-    done
-
 RUN apt-get update && \
     apt-get install exuberant-ctags && \
     apt-get install wget -y && \
@@ -28,6 +21,24 @@ RUN apt-get update && \
     pip install pylint python-language-server[all] ptvsd jedi && \
     apt-get purge -y --auto-remove gcc build-essential && \
     apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
+
+
+SHELL ["/bin/bash", "-c"]
+RUN command -v source || (echo "ERROR: Could not find 'source' command. SHELL may not supported. If you are using podman, try again with the '--format docker' flag." && exit 126)
+
+RUN cd "${HOME}"; \
+    python -m venv .venv ; \
+    source .venv/bin/activate; \
+    pip install -U ipykernel jupyter; \
+    python -m ipykernel install --name=.venv --user; \
+    mv "${HOME}"/.venv "${HOME}"/.venv-tmp
+
+RUN mkdir /projects && \
+    # Change permissions to let any arbitrary user
+    for f in "${HOME}" "/etc/passwd" "/projects"; do \
+      echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+      chmod -R g+rwX ${f}; \
+    done
 
 ADD etc/entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/sidecars/python/etc/entrypoint.sh
+++ b/sidecars/python/etc/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -20,7 +20,7 @@ GROUP_ID=$(id -g)
 export GROUP_ID
 
 if ! whoami >/dev/null 2>&1; then
-    echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/sh" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
 fi
 
 # Grant access to projects volume in case of non root user with sudo rights
@@ -28,4 +28,13 @@ if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /
     sudo chown "${USER_ID}:${GROUP_ID}" /projects
 fi
 
+# Setup .venv in the 'venv' volume that should be mounted in HOME/.venv
+mkdir -p "${HOME}"/.venv
+if [ ! -f "${HOME}"/.venv/bin/activate ]; then
+  echo "${HOME}"/.venv is empty, moving files from "${HOME}"/.venv-tmp/
+  mv "${HOME}"/.venv-tmp/* "${HOME}"/.venv
+fi
+
+# shellcheck source=/dev/null
+source "${HOME}"/.venv/bin/activate
 exec "$@"


### PR DESCRIPTION
Signed-off-by: Sun Seng David TAN <sutan@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Sidecar part, using the same venv folder for:
- jupyter notebook from the python plugin
- projects with dependencies in `requirements.txt`

### Screenshot/screencast of this PR

https://youtu.be/FPZa5jc8sYE


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16818

### How to test this PR?
will come with the plugin part (in a second PR once this is merged) but could be tested with:
```yaml
apiVersion: 1.0.0
metadata:
  generateName: python-jupyter-
projects:
  - name: jupyter-hello-world1
    source:
      startPoint: master
      location: 'https://github.com/chasbecker/TextAnalysis.git'
      type: git
components:
  - id: ms-python/python/latest
    registryUrl: 'https://sunix-che-plugin-registry-dev-i1viq.surge.sh/v3'
    type: chePlugin
  - mountSources: true
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: venv
        containerPath: /home/user/.venv
    image: 'quay.io/eclipse/che-python-3.8:7.29.0'
    alias: python
commands:
  - name: set up venv with requirements
    actions:
      - workdir: /home/user
        type: exec
        command: python -m venv .venv && . .venv/bin/activate && python -m pip install -r /projects/jupyter-hello-world1/requirements.txt
        component: python
```
and the flow:
1. open `AzureTextAnalyticsRestAPI.ipynb`
2. wait for the jupyter notebook to be loaded
3. try to run the first lines with imports
4. it should fail with errors that could not find the module `requests`
5. run the task `set up venv with requirements`
6. try to run again the first lines with imports
7. it should now fail: cannot find `pandas`
8. add to the file `requirements.txt` 
   ```
   pandas==1.2.4
   ```
9. run the task `set up venv with requirements`
10. try to run again the first lines with imports
11. it should now works, even the next part of the notebook

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
