### PR TITLE
Icon path must be relative to plugin registry root folder

### DIFF
--- a/tools/build/src/meta-yaml/meta-yaml-writer.ts
+++ b/tools/build/src/meta-yaml/meta-yaml-writer.ts
@@ -31,7 +31,12 @@ export class MetaYamlWriter {
   @inject(MetaYamlToDevfileYaml)
   private metaYamlToDevfileYaml: MetaYamlToDevfileYaml;
 
-  public static readonly DEFAULT_ICON = '/v3/images/eclipse-che-logo.png';
+  // Path relative to plugin registry ROOT
+  //    https://plugin-registry-eclipse-che.apps-crc.testing/v3
+  //
+  // It must work also for single root deployments
+  //    https://che-eclipse-che.apps-crc.testing/plugin-registry/v3
+  public static readonly DEFAULT_ICON = '/images/eclipse-che-logo.png';
 
   convertIdToPublisherAndName(id: string): [string, string] {
     const values = id.split('/');
@@ -66,7 +71,7 @@ export class MetaYamlWriter {
           const fileExtensionIcon = path.extname(path.basename(iconFile)).toLowerCase();
           const destIconFileName = `${publisher}-${name}-icon${fileExtensionIcon}`;
           await fs.copyFile(iconFile, path.resolve(imagesFolder, destIconFileName));
-          icon = `/v3/images/${destIconFileName}`;
+          icon = `/images/${destIconFileName}`;
         } else {
           icon = MetaYamlWriter.DEFAULT_ICON;
         }

--- a/tools/build/tests/meta-yaml/meta-yaml-writer.spec.ts
+++ b/tools/build/tests/meta-yaml/meta-yaml-writer.spec.ts
@@ -103,7 +103,7 @@ type: VS Code extension
 displayName: display-name
 title: my-title
 description: my-description
-icon: /v3/images/my-publisher-my-name-icon.png
+icon: /images/my-publisher-my-name-icon.png
 category: Programming Languages
 repository: 'http://fake-repository'
 firstPublicationDate: '2019-01-01'
@@ -161,7 +161,7 @@ type: VS Code extension
 displayName: display-name
 title: my-title
 description: my-description
-icon: /v3/images/eclipse-che-logo.png
+icon: /images/eclipse-che-logo.png
 category: Programming Languages
 repository: 'http://fake-repository'
 firstPublicationDate: '2019-01-01'
@@ -239,7 +239,7 @@ type: VS Code extension
 displayName: display-name
 title: my-title
 description: my-description
-icon: /v3/images/eclipse-che-logo.png
+icon: /images/eclipse-che-logo.png
 category: Programming Languages
 repository: 'http://fake-repository'
 firstPublicationDate: '2019-01-01'
@@ -319,7 +319,7 @@ type: VS Code extension
 displayName: display-name
 title: my-title
 description: my-description
-icon: /v3/images/eclipse-che-logo.png
+icon: /images/eclipse-che-logo.png
 category: Programming Languages
 repository: 'http://fake-repository'
 firstPublicationDate: '2019-01-01'
@@ -379,7 +379,7 @@ type: VS Code extension
 displayName: display-name
 title: my-title
 description: my-description
-icon: /v3/images/eclipse-che-logo.png
+icon: /images/eclipse-che-logo.png
 category: Programming Languages
 repository: 'http://fake-repository'
 firstPublicationDate: '2019-01-01'


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removes `/v3...` at the beginning of the icon path.
Having `/v3` gives wrong icon path for single root Che deployment.

It must work for both
- `https://plugin-registry-eclipse-che.apps-crc.testing/v3`
and
- `https://che-eclipse-che.apps-crc.testing/plugin-registry/v3`

If the icon without `/v3`, to show the icon Theia will just concatenate plugin registry root and icon path.

It needs to merge this PR together with https://github.com/eclipse-che/che-theia/pull/1118.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot from 2021-05-28 00-17-38](https://user-images.githubusercontent.com/1655894/119901310-6bb04300-bf4e-11eb-9588-26f2ad1dc247.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19771

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
