### PR TITLE
fix(dogfooding devfile): fix path of files to open from the didact guide that has changed after switch to multiroot.

### DIFF
--- a/.che-didact-guide.md
+++ b/.che-didact-guide.md
@@ -18,17 +18,17 @@ Enjoy!
 ## Adding or editing plugins and editors
 Since December 2020, populating the plugin registry is about editing the file `che-theia-plugins.yaml`. Editors could be customized from the file `che-editors.yaml`.
 
-- [Open che-theia-plugins.yaml](didact://?commandId=vscode.open&projectFilePath=che-plugin-registry%2Fche-theia-plugins.yaml&number=2)
-- [Open che-editors.yaml](didact://?commandId=vscode.open&projectFilePath=che-plugin-registry%2Fche-editors.yaml&number=2)
+- [Open che-theia-plugins.yaml](didact://?commandId=vscode.open&projectFilePath=che-theia-plugins.yaml&number=2)
+- [Open che-editors.yaml](didact://?commandId=vscode.open&projectFilePath=che-editors.yaml&number=2)
 
-More details on how to add plugins and editors: [Open CONTRIBUTE.md](didact://?commandId=markdown.showPreview&projectFilePath=che-plugin-registry%2FCONTRIBUTE.md)
+More details on how to add plugins and editors: [Open CONTRIBUTE.md](didact://?commandId=markdown.showPreview&projectFilePath=CONTRIBUTE.md)
 
 
 ## Building
 The predefined task `1. build` will start building the plugin registry. The result of the build is available in the project explorer `output` folder, child of che-plugin-registry folder.
 
 - [Run the `1. build` predefined task](didact://?commandId=workbench.action.tasks.runTask&text=1.%20build)
-- [Open the generated `che-plugin-registry/output/v3/plugins/index.json`](didact://?commandId=vscode.open&projectFilePath=che-plugin-registry%2Foutput%2Fv3%2Fplugins%2Findex.json&number=2)
+- [Open the generated `che-plugin-registry/output/v3/plugins/index.json`](didact://?commandId=vscode.open&projectFilePath=output%2Fv3%2Fplugins%2Findex.json&number=2)
 
 Generation could take some time, be patient :)
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When using the dogfooding devfile, the links to open files in the didact guide are broken because of the multi root workspace enabled (before we had 1 project `/projects` whereas now 1 project `/projects/che-plugin-registry`
This PR is fixing the paths.


### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
N/A


### How to test this PR?
Run the new devfile, try to open the files from the didact guide.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
