### PR TITLE
fix(push-ghpages): serving meta.yaml content when the full path is omitted

### DIFF
--- a/build/dev/publish-plugin-registry-to-gh-pages.sh
+++ b/build/dev/publish-plugin-registry-to-gh-pages.sh
@@ -34,6 +34,12 @@ git clone -b gh-pages "https://github.com/$GITHUB_REPOSITORY.git" "$GITHUB_REPO_
 cd "$GITHUB_REPO_NAME"
 [ -d "$VERSION_DIR" ] && git rm -r "$VERSION_DIR"
 cp -rf "$BUILD_DIR" "$VERSION_DIR"
+# Make meta.yaml as index
+for file in $(find . -name 'meta.yaml' -type f)
+do
+  PARENT_DIR=$(dirname $file);
+  cp ${PARENT_DIR}/meta.yaml ${PARENT_DIR}/index.json;
+done
 git add "$VERSION_DIR"
 git config user.email "che-bot@eclipse.org"
 git config user.name "CHE Bot"

--- a/build/dev/publish-plugin-registry-to-gh-pages.sh
+++ b/build/dev/publish-plugin-registry-to-gh-pages.sh
@@ -35,11 +35,11 @@ cd "$GITHUB_REPO_NAME"
 [ -d "$VERSION_DIR" ] && git rm -r "$VERSION_DIR"
 cp -rf "$BUILD_DIR" "$VERSION_DIR"
 # Make meta.yaml as index
-for file in $(find . -name 'meta.yaml' -type f)
+while IFS= read -r -d '' file
 do
   PARENT_DIR=$(dirname "$file");
   cp "${PARENT_DIR}"/meta.yaml "${PARENT_DIR}"/index.json;
-done
+done <   <(find . -name 'meta.yaml' -type f -print0)
 git add "$VERSION_DIR"
 git config user.email "che-bot@eclipse.org"
 git config user.name "CHE Bot"

--- a/build/dev/publish-plugin-registry-to-gh-pages.sh
+++ b/build/dev/publish-plugin-registry-to-gh-pages.sh
@@ -37,8 +37,8 @@ cp -rf "$BUILD_DIR" "$VERSION_DIR"
 # Make meta.yaml as index
 for file in $(find . -name 'meta.yaml' -type f)
 do
-  PARENT_DIR=$(dirname $file);
-  cp ${PARENT_DIR}/meta.yaml ${PARENT_DIR}/index.json;
+  PARENT_DIR=$(dirname "$file");
+  cp "${PARENT_DIR}"/meta.yaml "${PARENT_DIR}"/index.json;
 done
 git add "$VERSION_DIR"
 git config user.email "che-bot@eclipse.org"

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -37,6 +37,9 @@ components:
     image: 'quay.io/eclipse/che-plugin-registry:nightly'
     alias: eclipse-che-plugin-registry
 
+  - id: timonwong/shellcheck/latest
+    type: chePlugin
+
 commands:
 
   - name: 1. build


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
for the plugin registries published in gh-pages, serving meta.yaml content when the full path is omitted.
For instance https://eclipse-che.github.io/che-plugin-registry/7.30.1/v3/plugins/eclipse/che-theia/latest should display the content of the https://eclipse-che.github.io/che-plugin-registry/7.30.1/v3/plugins/eclipse/che-theia/latest/meta.yaml

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fix https://github.com/eclipse/che/issues/19820


### How to test this PR?
Either trust me and try https://sunix.github.io/che-plugin-registry/nightly/v3/plugins/

or
1. start the devfile out of this branch,
2. build the registry with the predifine command
3. in a terminal of the builder:

        export GITHUB_ACTOR=yourgithubusername; 
        export GITHUB_TOKEN=yourgithubtoken;
        ./build/dev/publish-plugin-registry-to-gh-pages.sh


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
