### PR TITLE
chore(npm): Make package not private so it can be published on npm registry

### DIFF
--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@eclipse-che/plugin-registry-generator",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "description": "Generator of yaml files exposed by the plug-in registry.",
   "main": "lib/entrypoint.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "lib",
     "src"


### PR DESCRIPTION

### What does this PR do?
Make package public so it can be published
Else we have the following error:
```
npm ERR! code EPRIVATE
npm ERR! This package has been marked as private
npm ERR! Remove the 'private' field from the package.json to publish it.
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19741

### How to test this PR?
you can look at https://github.com/eclipse-che/che-plugin-registry/runs/2715989741 that says
`Remove the 'private' field from the package.json to publish it.`


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I08d876d24a8555e8168c0263f7c97d0af8130478
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
