### PR TITLE
chore(publish): Rename the action to publish to 'publish' and also configure the registry to publish with node action

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -19,12 +19,14 @@ on:
     - '.github/workflows/typescript-publish.yml'
 
 jobs:
-  check:
+  publish:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-node@v1
       with:
         node-version: '12'
+        registry-url: 'https://registry.npmjs.org'
+        scope: '@eclipse-che'
     - name: Clone source code
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
### What does this PR do?
Setup the registry URL to publish
Else we have the following error:

```
npm ERR! 404 Not Found - PUT https://registry.npmjs.org/@eclipse-che%2fplugin-registry-generator - Not found
npm ERR! 404 
npm ERR! 404  '@eclipse-che/plugin-registry-generator@7.32.0-dev-a23d694' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
```


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19741


### How to test this PR?
you can look at https://github.com/eclipse-che/che-plugin-registry/runs/2718717324?check_suite_focus=true

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I9303179e77cadb0e358077ba0cab2b45607e546d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
