### PR TITLE
fix: don't rewrite 127 to 0.0.0.0

### DIFF
--- a/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
+++ b/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
@@ -78,10 +78,7 @@ export class MetaYamlToDevfileYaml {
 
     components.unshift(component);
 
-    // replace 127.0.0.1 by 0.0.0.0
-    return components.map(iteratingComponent =>
-      JSON.parse(JSON.stringify(iteratingComponent).replace(/127\.0\.0\.1/g, '0.0.0.0'))
-    );
+    return components;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types

--- a/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
+++ b/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
@@ -44,7 +44,7 @@ describe('Test MetaYamlToDevfileYaml', () => {
     expect(component.name).toBe('che-machine-exec');
     const componentContainer = component.container;
     expect(componentContainer.image).toBe('quay.io/eclipse/che-machine-exec:next');
-    expect(componentContainer.command).toStrictEqual(['/go/bin/che-machine-exec', '--url', '0.0.0.0:4444']);
+    expect(componentContainer.command).toStrictEqual(['/go/bin/che-machine-exec', '--url', '127.0.0.1:4444']);
 
     expect(componentContainer.endpoints).toBeDefined();
     expect(componentContainer.endpoints?.length).toBe(2);
@@ -87,8 +87,7 @@ describe('Test MetaYamlToDevfileYaml', () => {
 
     const theiaHostEnv = theiaIdeComponentContainer.env.find((env: any) => env.name === 'THEIA_HOST');
     expect(theiaHostEnv.name).toBe('THEIA_HOST');
-    // 127.0.0.1 should have been replaced by 0.0.0.0
-    expect(theiaHostEnv.value).toBe('0.0.0.0');
+    expect(theiaHostEnv.value).toBe('127.0.0.1');
 
     expect(theiaIdeComponentContainer.volumeMounts).toBeDefined();
     expect(theiaIdeComponentContainer.volumeMounts?.length).toBe(2);


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Don't replace 127.0.0.1. It is not secure to listen on all interfaces. After merging https://github.com/eclipse-che/che-operator/pull/1045 it is no longer needed.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20482


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
image `quay.io/mvala/che-plugin-registry:theiaSec`

1. deploy che with devworkspaces and plugin-registry ^
2. start a workspace
3. check theia really listens on 127.0.0.1 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
