### PR TITLE
Filter identical volume mounts in components list

### DIFF
--- a/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
+++ b/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
@@ -179,6 +179,14 @@ export class MetaYamlToDevfileYaml {
       devfileYaml.events = events;
       components = components.concat(componentsFromContainer);
     }
+
+    // remove duplicated components, e.g. plugins
+    // container and init container may provide two volumes with the same name
+    // and it is enough to have in components list only one volume definition
+    components = components.filter(function (item, pos, self) {
+      return self.findIndex(value => value.name === item.name) === pos;
+    });
+
     devfileYaml.components = components;
     return devfileYaml;
   }

--- a/tools/build/tests/_data/meta/che-theia-meta-with-multiple-volumes.yaml
+++ b/tools/build/tests/_data/meta/che-theia-meta-with-multiple-volumes.yaml
@@ -1,0 +1,49 @@
+apiVersion: v2
+publisher: eclipse
+name: che-theia
+version: next
+type: Che Editor
+displayName: theia-ide
+title: Eclipse Theia development version.
+description: 'Eclipse Theia, get the latest release each day.'
+icon: /images/default.png
+category: Editor
+repository: 'https://github.com/eclipse-che/che-theia'
+firstPublicationDate: '2019-03-07'
+latestUpdateDate: '2021-02-19'
+spec:
+  containers:
+    - name: theia-ide
+      image: 'quay.io/eclipse/che-theia:next'
+      mountSources: true
+      memoryLimit: 512M
+      memoryRequest: 50M
+      cpuLimit: 1500m
+      cpuRequest: 100m
+      volumes:
+        - name: plugins
+          mountPath: /plugins
+        - name: theia-local
+          mountPath: /home/theia/.theia
+    - name: che-machine-exec
+      image: 'quay.io/eclipse/che-machine-exec@next'
+      ports:
+        - exposedPort: 3333
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '127.0.0.1:3333'
+  initContainers:
+    - name: remote-runtime-injector
+      image: 'quay.io/eclipse/che-theia-endpoint-runtime-binary:next'
+      env:
+        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+          value: /remote-endpoint/plugin-remote-endpoint
+        - name: REMOTE_ENDPOINT_VOLUME_NAME
+          value: remote-endpoint
+      volumes:
+        - name: plugins
+          mountPath: /plugins
+        - name: remote-endpoint
+          mountPath: /remote-endpoint
+          ephemeral: true

--- a/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
+++ b/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
@@ -128,6 +128,21 @@ describe('Test MetaYamlToDevfileYaml', () => {
     expect(preStartFirstEvent).toBe('init-container-command');
   });
 
+  test('che-theia with multiple volumes which have identical name', async () => {
+    const metaYamlPath = path.resolve(__dirname, '..', '_data', 'meta', 'che-theia-meta-with-multiple-volumes.yaml');
+    const metaYamlContent = await fs.readFile(metaYamlPath, 'utf-8');
+    const metaYaml = jsYaml.safeLoad(metaYamlContent);
+    const devfileYaml = metaYamlToDevfileYaml.convert(metaYaml);
+    expect(devfileYaml.components?.length).toBe(6);
+    expect(devfileYaml.components?.find((value: any) => value.name === 'theia-ide')).toBeDefined();
+    expect(devfileYaml.components?.find((value: any) => value.name === 'plugins')).toBeDefined();
+    expect(devfileYaml.components?.find((value: any) => value.name === 'theia-local')).toBeDefined();
+    expect(devfileYaml.components?.find((value: any) => value.name === 'che-machine-exec')).toBeDefined();
+    expect(devfileYaml.components?.find((value: any) => value.name === 'remote-runtime-injector')).toBeDefined();
+    expect(devfileYaml.components?.find((value: any) => value.name === 'remote-endpoint')).toBeDefined();
+    expect(devfileYaml.components?.find((value: any) => value.name === 'non-existent')).toBeUndefined();
+  });
+
   test('no container', async () => {
     const metaYamlPath = path.resolve(__dirname, '..', '_data', 'meta', 'no-container.yaml');
     const metaYamlContent = await fs.readFile(metaYamlPath, 'utf-8');


### PR DESCRIPTION
### What does this PR do?
This changes proposal filter volume mounts that have identical names and leave only one volume configuration in components list.

The problem occurs after merging: https://github.com/eclipse-che/che-plugin-registry/pull/1055
So, the `remote-runtime-injector` and `theia-ide` components have two identical volume mounts, and devfile generator created two identical volume components, which prevented workspace startup. The solution for that issue is to filter identical components and leave only one configuration.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20545


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
