### PR TITLE
chore: Allow to skip the generation of meta.yaml

### DIFF
--- a/tools/build/src/editor/che-editors-meta-yaml-generator.ts
+++ b/tools/build/src/editor/che-editors-meta-yaml-generator.ts
@@ -55,6 +55,7 @@ export class CheEditorsMetaYamlGenerator {
         const iconFile = cheEditor.iconFile;
         const repository = metadata.attributes.repository;
         const firstPublicationDate = metadata.attributes.firstPublicationDate;
+        const skipMetaYaml = metadata.attributes.skipMetaYaml || false;
 
         const latestUpdateDate = new Date().toISOString().slice(0, 10);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,6 +90,7 @@ export class CheEditorsMetaYamlGenerator {
           firstPublicationDate,
           latestUpdateDate,
           spec,
+          skipMetaYaml,
         } as MetaYamlPluginInfo;
       })
     );

--- a/tools/build/src/meta-yaml/index-writer.ts
+++ b/tools/build/src/meta-yaml/index-writer.ts
@@ -24,10 +24,11 @@ export class IndexWriter {
   @named('OUTPUT_ROOT_DIRECTORY')
   private outputRootDirectory: string;
 
-  getLinks(plugin: MetaYamlPluginInfo): { self: string; devfile?: string } {
-    const links: { self: string; devfile?: string; plugin?: string } = {
-      self: `/v3/plugins/${plugin.id}`,
-    };
+  getLinks(plugin: MetaYamlPluginInfo): { self?: string; devfile?: string } {
+    const links: { self?: string; devfile?: string; plugin?: string } = {};
+    if (!plugin.skipMetaYaml) {
+      links.self = `/v3/plugins/${plugin.id}`;
+    }
     if (plugin.type === 'Che Editor' || plugin.type === 'Che Plugin') {
       links.devfile = `/v3/plugins/${plugin.id}/devfile.yaml`;
     } else if (plugin.type === 'VS Code extension') {

--- a/tools/build/src/meta-yaml/meta-yaml-plugin-info.ts
+++ b/tools/build/src/meta-yaml/meta-yaml-plugin-info.ts
@@ -25,6 +25,7 @@ export interface MetaYamlPluginInfo {
   firstPublicationDate: string;
   latestUpdateDate: string;
   aliases?: string[];
+  skipMetaYaml: boolean;
   skipIndex: boolean;
   spec: {
     containers?: [{ image: string; command?: string[]; args?: string[]; env?: { name: string; value: string }[] }];

--- a/tools/build/src/meta-yaml/meta-yaml-writer.ts
+++ b/tools/build/src/meta-yaml/meta-yaml-writer.ts
@@ -171,10 +171,13 @@ export class MetaYamlWriter {
             const generated = { ...metaYaml };
             generated.id = `${computedId}/${version}`;
             generated.skipIndex = plugin.skipIndex;
+            generated.skipMetaYaml = plugin.skipMetaYaml;
             metaYamlPluginGenerated.push(generated);
             const pluginPath = path.resolve(pluginsFolder, computedId, version, 'meta.yaml');
             await fs.ensureDir(path.dirname(pluginPath));
-            promises.push(fs.writeFile(pluginPath, yamlString));
+            if (!plugin.skipMetaYaml) {
+              promises.push(fs.writeFile(pluginPath, yamlString));
+            }
             if (devfileYaml) {
               const devfilePath = path.resolve(pluginsFolder, computedId, version, 'devfile.yaml');
               const devfileYamlString = jsyaml.safeDump(devfileYaml, { noRefs: true, lineWidth: -1 });

--- a/tools/build/src/registry/registry-helper.ts
+++ b/tools/build/src/registry/registry-helper.ts
@@ -52,7 +52,7 @@ export class RegistryHelper {
     const dockerImageName = parse(imageName);
 
     // do not use digest on nightlies/next
-    if (dockerImageName.tag === 'nightly' || dockerImageName.tag === 'next') {
+    if (dockerImageName.tag === 'nightly' || dockerImageName.tag === 'next' || dockerImageName.tag === 'insiders') {
       return imageName;
     }
     // do not grab digest of an image that is being published (if tag contains the current sha1)

--- a/tools/build/tests/meta-yaml/index-writer.spec.ts
+++ b/tools/build/tests/meta-yaml/index-writer.spec.ts
@@ -51,6 +51,7 @@ describe('Test IndexWriter', () => {
         publisher: 'my-publisher',
         type: 'Che Editor',
         version: 'my-version',
+        skipMetaYaml: true,
       } as any,
       {
         description: 'my-unknown-desc',
@@ -87,7 +88,8 @@ describe('Test IndexWriter', () => {
     // result has been sorted
     expect(jsonOutput[0].id).toBe('my-publisher/my-che-editor-name/latest');
     expect(jsonOutput[0].description).toBe('my-che-plugin');
-    expect(jsonOutput[0].links.self).toBe('/v3/plugins/my-publisher/my-che-editor-name/latest');
+    // no metaYaml generation option enabled for this editor
+    expect(jsonOutput[0].links.self).toBeUndefined();
     expect(jsonOutput[0].links.devfile).toBe('/v3/plugins/my-publisher/my-che-editor-name/latest/devfile.yaml');
     expect(jsonOutput[0].name).toBe('my-che-editor-name');
     expect(jsonOutput[0].publisher).toBe('my-publisher');

--- a/tools/build/tests/meta-yaml/meta-yaml-writer.spec.ts
+++ b/tools/build/tests/meta-yaml/meta-yaml-writer.spec.ts
@@ -47,6 +47,7 @@ describe('Test MetaYamlWriter', () => {
     metaPluginYaml = {
       id: 'custom-publisher/custom-name',
       skipIndex: false,
+      skipMetaYaml: false,
       aliases: ['first/alias', 'second/alias'],
       publisher: 'my-publisher',
       name: 'my-name',
@@ -412,6 +413,7 @@ spec: {}
       apiVersion: 'v2',
       id: 'foo/bar',
       publisher: 'foo',
+      skipMetaYaml: true,
       name: 'bar',
       version: '0.0.1',
       displayName: 'minimal-endpoint',
@@ -443,10 +445,11 @@ spec: {}
     metaYamlToDevfileYamlConvertMethod.mockReturnValue({ devfileFakeResult: 'dummy' });
     await metaYamlWriter.write(metaYamlPlugins);
 
-    expect(fsWriteFileSpy).toHaveBeenCalledTimes(2);
+    // we skipped meta.yaml generation
+    expect(fsWriteFileSpy).toHaveBeenCalledTimes(1);
 
     expect(fsWriteFileSpy).toHaveBeenNthCalledWith(
-      2,
+      1,
       '/fake-output/v3/plugins/foo/bar/latest/devfile.yaml',
       'devfileFakeResult: dummy\n'
     );


### PR DESCRIPTION
### What does this PR do?
For example for VS Code we want to support only for DevWorkspaces (so no meta.yaml should be generated)

so this PR allow to bypass meta.yaml generation

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20505

### How to test this PR?
There are tests checking this behavior

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I5094de43d74102f1fbaeebbdcee0de602b6ef29c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>