### PR TITLE
feat: DevWorkspaces endpoint path is a field, not an atttribute

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -600,7 +600,7 @@ editors:
                 cookiesAuthEnabled: true
                 discoverable: false
                 urlRewriteSupported: true
-                path: '?tkn=eclipse-che'
+              path: '?tkn=eclipse-che'
               targetPort: 3100
               exposure: public
               secure: true

--- a/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
+++ b/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
@@ -118,6 +118,10 @@ export class MetaYamlToDevfileYaml {
           devfileEndpoint.exposure = 'public';
         }
 
+        if (endpoint.path) {
+          devfileEndpoint.path = endpoint.path;
+        }
+
         // ide type is moved to more generic main endpoint
         if (endpoint.attributes && endpoint.attributes['type'] === 'ide') {
           devfileEndpoint.attributes['type'] = 'main';

--- a/tools/build/tests/_data/meta/container-minimal-endpoint.yaml
+++ b/tools/build/tests/_data/meta/container-minimal-endpoint.yaml
@@ -4,6 +4,7 @@ spec:
   endpoints:
     - name: www
       targetPort: 3100
+      path: /hello
   containers:
     - name: minimal-endpoint
       image: 'quay.io/minimal-endpoint'

--- a/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
+++ b/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
@@ -201,6 +201,7 @@ describe('Test MetaYamlToDevfileYaml', () => {
     expect(componentContainer.endpoints?.length).toBe(1);
     const wwwEndpoint = componentContainer.endpoints[0];
     expect(wwwEndpoint.name).toBe('www');
+    expect(wwwEndpoint.path).toBe('/hello');
     expect(wwwEndpoint.exposure).toBeUndefined();
     expect(wwwEndpoint.attributes).toBeUndefined();
   });


### PR DESCRIPTION
### What does this PR do?
move path attribute to the upper endpoint field as path is a known keyword in Devfile v2 scope

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20505


### How to test this PR?
Look at generated devfile.yaml, path should be a field of the endpoint
or look at unit tests


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
Change-Id: I6e1a9c660911ebe037930f60b4f4a410e2d3f4c0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
