### PR TITLE
chore: do not add .pnp / cache folder as it's in .gitignore

### DIFF
--- a/.github/workflows/dependabot-pr-workaround.yml
+++ b/.github/workflows/dependabot-pr-workaround.yml
@@ -67,6 +67,6 @@ jobs:
     - name: Commit changes
       run: |
         cd .`git log -1 --pretty=%s | awk '{ print $9 }'` # ditto
-        git add yarn.lock .yarn/cache .pnp.* # only add yarn.lock if not using zero-installs
-        git commit -m "Dependabot autofix"
+        git add yarn.lock # only adding yarn.lock as not using zero-installs
+        git commit -m "fix: dependabot autofix"
         git push


### PR DESCRIPTION
### What does this PR do?
In dependabot fix job, do not add .pnp / cache folder as it's in .gitignore

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fix dependabot PR

### How to test this PR?
Check github action

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I890fdee555c486ff221eeea5021bfd7fea49b8ac
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
