### PR TITLE
chore: update commit template to use...

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -83,9 +83,9 @@ commitChangeOrCreatePR()
     PR_BRANCH="$3"
 
     if [[ ${PR_BRANCH} == *"add"* ]]; then
-      COMMIT_MSG="chore: Add ${aVERSION} plugins in ${aBRANCH}"
+      COMMIT_MSG="chore: release: add ${aVERSION} plugins in ${aBRANCH}"
     else 
-      COMMIT_MSG="chore: Bump to ${aVERSION} in ${aBRANCH}"
+      COMMIT_MSG="chore: release: bump to ${aVERSION} in ${aBRANCH}"
     fi
 
     # commit change into branch


### PR DESCRIPTION
### What does this PR do?

chore: update commit template to use semantic commit (#19912)

Change-Id: I40dea6f6711a8982bd3466149500de954526445b
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.