### PR TITLE
chore: use secrets for dependabot

### DIFF
--- a/.github/workflows/dependabot-pr-workaround.yml
+++ b/.github/workflows/dependabot-pr-workaround.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Red Hat, Inc.
+# Copyright (c) 2021-2022 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,9 +10,6 @@
 name: Dependabot-post-check
 # dependabot is not handling Yarn v2/3, workarounding the PR
 # https://github.com/dependabot/dependabot-core/issues/1297
-
-permissions:
-  contents: write
 
 on:
   push:
@@ -26,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
+          token: ${{secrets.CHE_BOT_GITHUB_TOKEN}}
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -41,9 +39,9 @@ jobs:
       - name: Config Git
         run: |
           git config --global user.email "che-bot@eclipse.org"
-          git config --global user.name "CHE Bot"
+          git config --global user.name "Che bot"
       - name: Commit changes
         run: |
           git add yarn.lock # only adding yarn.lock as not using zero-installs
-          git commit --amend --no-edit
+          git commit --amend --no-edit --signoff
           git push -f


### PR DESCRIPTION
### What does this PR do?
Allow to override the author of the PR when amending the dependabot PR
It allows to trigger current workflows.
Else, when using the dependabot identity, there is no workflow action triggered to avoid infinite loop

This is now possible as Github released this night github dependabot secrets API
`https://github.com/dependabot/dependabot-core/issues/3297#issuecomment-1009308206`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
So all our PR checks will be run on the dependabot PR


### How to test this PR?
I've tested on a forked repository


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
