### PR TITLE
Add volume for storing Projector configuration between workspace restarts

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -562,6 +562,8 @@ editors:
           volumeMounts:
             - name: projector-volume
               path: /projector
+            - name: projector-configuration
+              path: /home/user/.jetbrains
           memoryLimit: 2048Mi
           memoryRequest: 256Mi
           cpuLimit: 500m
@@ -582,6 +584,8 @@ editors:
           app.kubernetes.io/component: che-idea-injector
           app.kubernetes.io/part-of: che-idea.eclipse.org
       - name: projector-volume
+        volume: { }
+      - name: projector-configuration
         volume: { }
       - name: che-idea-injector
         container:
@@ -633,6 +637,8 @@ editors:
           volumeMounts:
             - name: projector-volume
               path: /projector
+            - name: projector-configuration
+              path: /home/user/.jetbrains
           memoryLimit: 2048Mi
           memoryRequest: 256Mi
           cpuLimit: 500m
@@ -653,6 +659,8 @@ editors:
           app.kubernetes.io/component: che-pycharm-injector
           app.kubernetes.io/part-of: che-pycharm.eclipse.org
       - name: projector-volume
+        volume: { }
+      - name: projector-configuration
         volume: { }
       - name: che-pycharm-injector
         container:


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds volume mount for storing Projector configuration between workspace restarts. This allows to restore IDE state after workspace start.

This PR should be merged only after merge https://github.com/che-incubator/jetbrains-editor-images/pull/74

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21011


### How to test this PR?
Create workspace from the following link on minikube:
```
https://<your-che-host>/dashboard/#https://github.com/che-incubator/jetbrains-editor-images?che-editor=https://gist.github.com/vzhukovs/55caad47363e1b4f3d4a6ab3fe85a03a/raw/4ca14714fb4da371596cef2aa9aa6afbcbe4c2a1/devfile.yaml
```
Go to File - Save All and then restart the workspace. Editor state should be restored.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
