### PR TITLE
Use next image tag instead of <version>-next

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -614,7 +614,7 @@ editors:
         volume: { }
       - name: che-idea-injector
         container:
-          image: 'quay.io/che-incubator/che-idea:2020.3.4-next'
+          image: 'quay.io/che-incubator/che-idea:next'
           command: [ "/projector/entrypoint-init-container.sh" ]
           env:
             - name: PROJECTOR_VOLUME_MOUNT
@@ -772,7 +772,7 @@ editors:
         volume: { }
       - name: che-pycharm-injector
         container:
-          image: 'quay.io/che-incubator/che-pycharm:2020.3.5-next'
+          image: 'quay.io/che-incubator/che-pycharm:next'
           command: [ "/projector/entrypoint-init-container.sh" ]
           env:
             - name: PROJECTOR_VOLUME_MOUNT


### PR DESCRIPTION
### What does this PR do?
Use published `next` tags instead of `<version>-next` to avoid missing manifest in case if `<version>-next` is updated.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21031


### How to test this PR?
For che-idea it is enough to create the workspace from the following repository:
```
https://github.com/vzhukovs/demo-repository/tree/che-21031-idea
```

For che-pycharm:
```
https://github.com/vzhukovs/demo-repository/tree/che-21031-pycharm
```

in both cases the `next` tag should be fetched and the workspace should be opened.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
