### PR TITLE
test: Don't start not adapted plugins tests on openshift-ci nightly job

### DIFF
--- a/.ci/openshift-ci/nightly-test.sh
+++ b/.ci/openshift-ci/nightly-test.sh
@@ -24,19 +24,19 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}"/common-functions.sh
 
 runTests() {
-  runTest "InstallPluginUsingUI" "install-plugin-test"
-  runTest "JavaPlugin" "java11-plugin-test"
-  runTest "PhpPlugin" "php-plugin-test"
-  runTest "PythonPlugin" "python-plugin-test"
+# runTest "InstallPluginUsingUI" "install-plugin-test"
+# runTest "JavaPlugin" "java11-plugin-test"
+# runTest "PhpPlugin" "php-plugin-test"
+# runTest "PythonPlugin" "python-plugin-test"
   runTest "TypescriptPlugin" "typescript-debug-plugins"
-  runTest "VscodeKubernetesPlugin" "nodejs-24lop"
-  runTest "VscodeShellcheckPlugin" "nodejs-zmecm"
-  runTest "VscodeValePlugin" "che-docs-test"
-  runTest "VscodeXmlPlugin" "xml-plugin-test"
+# runTest "VscodeKubernetesPlugin" "nodejs-24lop"
+# runTest "VscodeShellcheckPlugin" "nodejs-zmecm"
+# runTest "VscodeValePlugin" "che-docs-test"
+# runTest "VscodeXmlPlugin" "xml-plugin-test"
   runTest "VscodeYamlPlugin" "nodejs-zmecm"
-  runTest "GitHubPullRequestPlugin" "github-pr-plugin"
+# runTest "GitHubPullRequestPlugin" "github-pr-plugin"
 }
 
-# setupTestEnvironment
-# runTests
-# finishReport
+setupTestEnvironment
+runTests
+finishReport

--- a/.ci/openshift-ci/nightly-test.sh
+++ b/.ci/openshift-ci/nightly-test.sh
@@ -37,6 +37,6 @@ runTests() {
   runTest "GitHubPullRequestPlugin" "github-pr-plugin"
 }
 
-setupTestEnvironment
-runTests
-finishReport
+# setupTestEnvironment
+# runTests
+# finishReport


### PR DESCRIPTION
### What does this PR do?
Don't start not adapted plugins tests on openshift-ci nightly job. For now only 2 plugins test updated.

### What issues does this PR fix or reference?
This issue is a part of https://github.com/eclipse/che/issues/21210.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
