### PR TITLE
chore: plugin reg updates to move away from download.jboss.org (CRW-2662) & update to newer versions

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -311,7 +311,7 @@ plugins:
       automigrate: false
   - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
-      revision: 0.1.0
+      revision: 0.2.1
     aliases:
       - redhat/dependency-analytics
     sidecar:
@@ -347,7 +347,7 @@ plugins:
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-project-initializer/project-initializer-0.0.10-582.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-openshift-tools'
-      revision: v0.2.9
+      revision: v0.2.13
     sidecar:
       directory: openshift-tooling
       name: vscode-openshift-connector
@@ -358,7 +358,7 @@ plugins:
       volumeMounts:
         - name: kube
           path: /home/theia/.kube
-    extension: https://open-vsx.org/api/redhat/vscode-openshift-connector/0.2.9/file/redhat.vscode-openshift-connector-0.2.9.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-openshift-connector/0.2.13/file/redhat.vscode-openshift-connector-0.2.13.vsix
     metaYaml:
       extraDependencies:
         - ms-kubernetes-tools/vscode-kubernetes-tools
@@ -399,7 +399,7 @@ plugins:
       memoryLimit: 1500Mi
       memoryRequest: 20Mi
       cpuLimit: 800m
-      cpuRequest: 30m      
+      cpuRequest: 30m
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
   - id: redhat/java
     repository:

--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -11,19 +11,8 @@ plugins:
       - ms-vscode/vscode-github-pullrequest
     extension: https://github.com/microsoft/vscode-pull-request-github/releases/download/0.21.1/vscode-pull-request-github-0.21.1.vsix
   - repository:
-      url: 'https://github.com/Microsoft/vscode-node-debug'
-      revision: v1.44.8
-    sidecar:
-      directory: node
-      name: vscode-node-debug
-      memoryLimit: 512Mi
-      memoryRequest: 20Mi
-      cpuLimit: 500m
-      cpuRequest: 30m
-    extension: https://open-vsx.org/api/ms-vscode/node-debug/1.44.8/file/ms-vscode.node-debug-1.44.8.vsix
-  - repository:
-      url: 'https://github.com/Microsoft/vscode-node-debug'
-      revision: v1.52.2
+      url: 'https://github.com/microsoft/vscode-js-debug'
+      revision: v1.66.0
     sidecar:
       directory: node
       name: jsdebug
@@ -31,23 +20,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://open-vsx.org/api/ms-vscode/js-debug/1.52.2/file/ms-vscode.js-debug-1.52.2.vsix
-  - repository:
-      url: 'https://github.com/Microsoft/vscode-node-debug2'
-      revision: v1.42.5
-    metaYaml:
-      extraDependencies:
-        - ms-vscode/node-debug
-    preferences:
-      debug.node.useV3: false
-    sidecar:
-      directory: node
-      name: vscode-node-debug
-      memoryLimit: 512Mi
-      memoryRequest: 20Mi
-      cpuLimit: 500m
-      cpuRequest: 30m
-    extension: https://open-vsx.org/api/ms-vscode/node-debug2/1.42.5/file/ms-vscode.node-debug2-1.42.5.vsix
+    extension: https://open-vsx.org/api/ms-vscode/js-debug/1.66.0/file/ms-vscode.js-debug-1.66.0.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode'
       revision: 1.49.3
@@ -106,7 +79,7 @@ plugins:
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v8130b13/vale-vscode-v0.14.2.vsix
   - repository:
       url: https://github.com/clangd/vscode-clangd
-      revision: c7f4a1b84fcc10d5b8241750cf2a84097ee4c37e
+      revision: 0.1.15
     metaYaml:
      skipIndex: true
     sidecar:
@@ -116,10 +89,10 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-clangd/vscode-clangd-0.1.5-562d00.vsix
+    extension: https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.15/file/llvm-vs-code-extensions.vscode-clangd-0.1.15.vsix
   - repository:
       url: https://github.com/eclipse-cdt/cdt-gdb-vscode
-      revision: 2cbbb857a2acf0b2e46bab30e0cbbfb547514856
+      revision: 528a63de7e21d3e62d9e8aad6491718b69ec311e
     metaYaml:
      skipIndex: true
     sidecar:
@@ -129,7 +102,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-gdb-vscode/cdt-gdb-vscode-0.0.91-2cbbb8.vsix
+    extension: https://open-vsx.org/api/eclipse-cdt/cdt-gdb-vscode/0.0.92/file/eclipse-cdt.cdt-gdb-vscode-0.0.92.vsix
   - repository:
       url: 'https://github.com/eclipse-cdt/cdt-vscode'
       revision: 2edfc3a3474bc7a732014e1a4631561b991f845a
@@ -141,10 +114,10 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-vscode/cdt-vscode-0.0.7-75cf95.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/0.0.7-75cf95-cdt-vscode-assets/cdt-vscode-0.0.7-75cf95.vsix
   - repository:
       url: 'https://github.com/bmewburn/vscode-intelephense'
-      revision: v1.5.4
+      revision: v1.8.2
     featured: true
     sidecar:
       directory: php
@@ -152,7 +125,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.5.4.vsix
+    extension: https://open-vsx.org/api/bmewburn/vscode-intelephense-client/1.8.2/file/bmewburn.vscode-intelephense-client-1.8.2.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode-python'
       revision: 2020.7.94776
@@ -167,7 +140,7 @@ plugins:
       volumeMounts:
         - name: venv
           path: /home/theia/.venv
-    extension: https://github.com/microsoft/vscode-python/releases/download/2020.7.94776/ms-python-release.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v34b6b7e/vscode-python-2020.7.94776.vsix
   - repository:
       url: 'https://github.com/asciidoctor/asciidoctor-vscode'
       revision: v2.8.7
@@ -223,7 +196,7 @@ plugins:
         - redhat/vscode-yaml
   - repository:
       url: 'https://github.com/camel-tooling/vscode-camelk'
-      revision: 0.0.26
+      revision: 0.0.30
     sidecar:
       directory: camelk
       name: vscode-camelk
@@ -231,10 +204,10 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.26-336.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-camelk/0.0.30/file/redhat.vscode-camelk-0.0.30.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-microprofile'
-      revision: 174c77f51a57bf1cfadba8f78ad7072ce63baa1d
+      revision: 0.3.0
     sidecar:
       directory: java
       name: vscode-microp
@@ -245,11 +218,11 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-microprofile/vscode-microprofile-0.1.1-48.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-microprofile/0.3.0/file/redhat.vscode-microprofile-0.3.0.vsix
   - id: redhat/vscode-quarkus
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
-      revision: v1.7.0
+      revision: v1.9.0
     aliases:
       - redhat/quarkus-java11
     preferences:
@@ -264,7 +237,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-quarkus/vscode-quarkus-1.7.0-437.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-quarkus/1.9.0/file/redhat.vscode-quarkus-1.9.0.vsix
     metaYaml:
       skipDependencies:
         - redhat/vscode-commons
@@ -286,7 +259,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-quarkus/vscode-quarkus-1.5.0-324.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-quarkus/1.5.0/file/redhat.vscode-quarkus-1.5.0.vsix
     skipDependencies:
         - redhat/java
     extraDependencies:
@@ -298,20 +271,8 @@ plugins:
         - vscjava/vscode-java-debug
         - vscjava/vscode-java-test
   - repository:
-      url: 'https://github.com/camel-tooling/vscode-wsdl2rest'
-      revision: 0.0.11
-    sidecar:
-      directory: java8
-      memoryLimit: 256Mi
-      memoryRequest: 20Mi
-      cpuLimit: 800m
-      cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.11-106.vsix
-    deprecate:
-      automigrate: false
-  - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
-      revision: 0.2.1
+      revision: 0.3.5
     aliases:
       - redhat/dependency-analytics
     sidecar:
@@ -321,7 +282,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.2.1/fabric8-analytics-0.2.1.vsix
+    extension: https://open-vsx.org/api/redhat/fabric8-analytics/0.3.5/file/redhat.fabric8-analytics-0.3.5.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-tekton'
       revision: v0.2.0
@@ -343,8 +304,10 @@ plugins:
         - ms-kubernetes-tools/vscode-kubernetes-tools
   - repository:
       url: 'https://github.com/redhat-developer/vscode-project-initializer'
-      revision: v0.0.10
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-project-initializer/project-initializer-0.0.10-582.vsix
+      revision: v0.2.1
+    aliases:
+      - redhat/project-initializer
+    extension: https://open-vsx.org/api/redhat/project-initializer/0.2.1/file/redhat.project-initializer-0.2.1.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-openshift-tools'
       revision: v0.2.13
@@ -400,7 +363,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
+    extension: https://open-vsx.org/api/vscjava/vscode-java-debug/0.26.0/file/vscjava.vscode-java-debug-0.26.0.vsix
   - id: redhat/java
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
@@ -420,7 +383,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix
+    extension: https://open-vsx.org/api/redhat/java/0.82.0/file/redhat.java-0.82.0.vsix
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
@@ -441,14 +404,14 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.63.0-2222.vsix
+    extension: https://open-vsx.org/api/redhat/java/0.63.0/file/redhat.java-0.63.0.vsix
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
         - vscjava/vscode-java-test
   - repository:
       url: 'https://github.com/felixfbecker/vscode-php-debug'
-      revision: v1.13.0
+      revision: v1.22.0
     aliases:
       - felixfbecker/vscode-php-debug
       - redhat/php-debugger
@@ -459,7 +422,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix
+    extension: https://open-vsx.org/api/felixfbecker/php-debug/1.22.0/file/felixfbecker.php-debug-1.22.0.vsix
   - repository:
       url: 'https://github.com/windup/rhamt-vscode-extension'
       revision: a03a76e372f70deaa68743e400a4e7e18e5eb221
@@ -487,10 +450,10 @@ plugins:
           targetPort: 61435
           attributes:
             protocol: http
-    extension: https://download.jboss.org/jbosstools/vscode/stable/mta-vscode-extension/mta-vscode-extension-0.0.63-49.vsix
+    extension: https://open-vsx.org/api/redhat/mta-vscode-extension/0.0.63/file/redhat.mta-vscode-extension-0.0.63.vsix
   - repository:
       url: 'https://github.com/camel-tooling/camel-lsp-client-vscode'
-      revision: 0.1.5
+      revision: 0.2.0
     sidecar:
       directory: java
       name: vscode-apache-camel
@@ -498,10 +461,13 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.1.5-1377.vsix
+    extension: https://open-vsx.org/api/redhat/vscode-apache-camel/0.2.0/file/redhat.vscode-apache-camel-0.2.0.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-xml'
       revision: 0.17.0
+    preferences:
+      xml.server.binary.trustedHashes:
+        - "b8e08163ffff7561060e10f142a52655ea1a5d9a"
     featured: true
     sidecar:
       directory: java
@@ -511,6 +477,9 @@ plugins:
       cpuLimit: 500m
       cpuRequest: 30m
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v069c634/vscode-xml-0.17.0.vsix
+    metaYaml:
+      skipDependencies:
+        - redhat/vscode-commons
   - repository:
       url: https://github.com/redhat-developer/vscode-didact
       revision: 0.4.0
@@ -525,7 +494,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.2.1.vsix
+    extension: https://open-vsx.org/api/ms-kubernetes-tools/vscode-kubernetes-tools/1.2.1/file/ms-kubernetes-tools.vscode-kubernetes-tools-1.2.1.vsix
   - repository:
       url: 'https://github.com/rogalmic/vscode-bash-debug'
       revision: v0.3.9
@@ -616,7 +585,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://github.com/SonarSource/sonarlint-vscode/releases/download/1.20.1/sonarlint-vscode-1.20.1.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v8521e74/vscode-sonarlint-1.20.1.vsix
   - repository:
       url: 'https://bitbucket.org/atlassianlabs/atlascode'
       revision: 2.8.6
@@ -793,8 +762,8 @@ plugins:
     extension: https://open-vsx.org/api/esbenp/prettier-vscode/5.8.0/file/esbenp.prettier-vscode-5.8.0.vsix
   - repository:
       url: 'https://github.com/microsoft/vscode-eslint'
-      revision: 1e15d3495da89072d48cf583d48d92829f0c4b82
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-eslint-2.1.1-1e15d3.vsix
+      revision: release/2.1.20
+    extension: https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.20/file/dbaeumer.vscode-eslint-2.1.20.vsix
   - repository:
       url: 'https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight'
       revision: 'd4247b5feadd92d429d69a6b511f5ed0e1011895'


### PR DESCRIPTION
### What does this PR do?

Fix / chore: followup to #19952 

Removals:

* remove obsolete node-debug and node-debug2
* wsdl2rest removed (per @apupier this is no longer needed)

Updates / URL changes:

* vscode-js-debug 1.52.2 -> 1.66.0 (also fix GH project URL)
* clangd 0.1.5 -> 0.1.15 
* cdt-gdb-vscode 0.0.91 -> 0.0.92
* php intelephense-client 1.5.4 -> 1.8.2
* camelk 0.0.26 -> 0.0.30
* microprofile-0.1.1 -> 0.3.0
* quarkus 1.7 -> 1.9
* fabric8-analytics 0.2.1 (was mislabelled as 0.1.0) -> 0.3.5
* project-initializer 0.0.10 -> 0.2.1
* openshift-connector 0.2.9 -> 0.2.13
* php-debug 1.13 -> 1.22.0
* eslint-2.1.1 -> 2.1.20

URL change only:

* cdt-vscode-0.0.7-75cf95 (unchanged, just moved host)
* python (unchanged, just moved host)
* quarkus 1.5 -> 1.5 (unchanged, just moved host; needed for JDK 8)
* java-debug-0.26.0 (moved host only)
* redhat.java-0.82.0 (moved host only)
* redhat.java-0.63.0 (moved host only; for JDK 8)
* mta 0.0.63 (moved host only) @johnsteele FYI if you want something newer, submit a PR
* kubernetes-tools-1.2.1 (moved host only)
* sonarlint-1.20.1 (moved host only)

Questions:

* apache-camel 0.1.5 -> 0.2.0 **** NOT SURE about `trustedHashes` annotation? @apupier 
* xml 0.1.7 **** NOT SURE about `skipDependencies` annotation?  @benoitf 

This PR also includes the changes in https://github.com/eclipse-che/che-plugin-registry/pull/1221 

Change-Id: I5dec0733ab2fc316027cfae42ecd513b17546493
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19952
https://issues.redhat.com/browse/CRW-2662

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.