### PR TITLE
chore: CRW-2662 upload all the old vsix...

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -116,7 +116,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-clangd/vscode-clangd-0.1.5-562d00.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-clangd-0.1.5-562d00.vsix
   - repository:
       url: https://github.com/eclipse-cdt/cdt-gdb-vscode
       revision: 2cbbb857a2acf0b2e46bab30e0cbbfb547514856
@@ -129,7 +129,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-gdb-vscode/cdt-gdb-vscode-0.0.91-2cbbb8.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/cdt-gdb-vscode-0.0.91-2cbbb8.vsix
   - repository:
       url: 'https://github.com/eclipse-cdt/cdt-vscode'
       revision: 2edfc3a3474bc7a732014e1a4631561b991f845a
@@ -141,7 +141,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-vscode/cdt-vscode-0.0.7-75cf95.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/cdt-vscode-0.0.7-75cf95.vsix
   - repository:
       url: 'https://github.com/bmewburn/vscode-intelephense'
       revision: v1.5.4
@@ -152,7 +152,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.5.4.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-intelephense-client-1.5.4.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode-python'
       revision: 2020.7.94776
@@ -191,7 +191,7 @@ plugins:
       revision: v10.2.1
     aliases:
       - eamodio/vscode-gitlens
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-gitlens/gitlens-10.2.1.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/gitlens-10.2.1.vsix
   - repository:
       url: 'https://github.com/golang/vscode-go'
       revision: v0.23.0
@@ -231,7 +231,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.26-336.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-camelk-0.0.26-336.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-microprofile'
       revision: 174c77f51a57bf1cfadba8f78ad7072ce63baa1d
@@ -245,7 +245,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-microprofile/vscode-microprofile-0.1.1-48.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-microprofile-0.1.1-48.vsix
   - id: redhat/vscode-quarkus
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
@@ -264,7 +264,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-quarkus/vscode-quarkus-1.7.0-437.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-quarkus-1.7.0-437.vsix
     metaYaml:
       skipDependencies:
         - redhat/vscode-commons
@@ -286,7 +286,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-quarkus/vscode-quarkus-1.5.0-324.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-quarkus-1.5.0-324.vsix
     skipDependencies:
         - redhat/java
     extraDependencies:
@@ -306,7 +306,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.11-106.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-wsdl2rest-0.0.11-106.vsix
     deprecate:
       automigrate: false
   - repository:
@@ -337,14 +337,14 @@ plugins:
       volumeMounts:
         - name: kube
           path: /home/theia/.kube
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-tekton/vscode-tekton-pipelines-0.2.0.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-tekton-pipelines-0.2.0.vsix
     metaYaml:
       extraDependencies:
         - ms-kubernetes-tools/vscode-kubernetes-tools
   - repository:
       url: 'https://github.com/redhat-developer/vscode-project-initializer'
       revision: v0.0.10
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-project-initializer/project-initializer-0.0.10-582.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/project-initializer-0.0.10-582.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-openshift-tools'
       revision: v0.2.9
@@ -400,7 +400,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m      
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-java-debug-0.26.0.vsix
   - id: redhat/java
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
@@ -420,7 +420,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/java-0.82.0-369.vsix
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
@@ -441,7 +441,7 @@ plugins:
       volumeMounts:
         - name: m2
           path: /home/theia/.m2
-    extension: https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.63.0-2222.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/java-0.63.0-2222.vsix
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
@@ -459,7 +459,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/php-debug-1.13.0.vsix
   - repository:
       url: 'https://github.com/windup/rhamt-vscode-extension'
       revision: a03a76e372f70deaa68743e400a4e7e18e5eb221
@@ -487,7 +487,7 @@ plugins:
           targetPort: 61435
           attributes:
             protocol: http
-    extension: https://download.jboss.org/jbosstools/vscode/stable/mta-vscode-extension/mta-vscode-extension-0.0.63-49.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/mta-vscode-extension-0.0.63-49.vsix
   - repository:
       url: 'https://github.com/camel-tooling/camel-lsp-client-vscode'
       revision: 0.1.5
@@ -498,7 +498,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.1.5-1377.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-apache-camel-0.1.5-1377.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-xml'
       revision: 0.17.0
@@ -514,7 +514,7 @@ plugins:
   - repository:
       url: https://github.com/redhat-developer/vscode-didact
       revision: 0.4.0
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-didact/vscode-didact-0.4.0-309.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-didact-0.4.0-309.vsix
   - repository:
       url: 'https://github.com/Azure/vscode-kubernetes-tools'
       revision: 1.2.1
@@ -525,7 +525,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.2.1.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-kubernetes-tools-1.2.1.vsix
   - repository:
       url: 'https://github.com/rogalmic/vscode-bash-debug'
       revision: v0.3.9
@@ -671,7 +671,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-proto3/vscode-proto3-0.4.2-c4d9ee.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-proto3-0.4.2-c4d9ee.vsix
   - repository:
       url: 'https://github.com/timonwong/vscode-shellcheck'
       revision: v0.13.2
@@ -794,7 +794,7 @@ plugins:
   - repository:
       url: 'https://github.com/microsoft/vscode-eslint'
       revision: 1e15d3495da89072d48cf583d48d92829f0c4b82
-    extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-eslint-2.1.1-1e15d3.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-eslint-2.1.1-1e15d3.vsix
   - repository:
       url: 'https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight'
       revision: 'd4247b5feadd92d429d69a6b511f5ed0e1011895'


### PR DESCRIPTION
### What does this PR do?

chore: [CRW-2662](https://issues.redhat.com/browse/CRW-2662) upload all the old vsix files from Che 7.44 to GH release; update URL refs

Change-Id: I3ea8667513a442ff2dcf5afdef994e07f418c418
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
[CRW-2662](https://issues.redhat.com/browse/CRW-2662)

### How to test this PR?

assets uploaded to https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/tag/7.44-che-assets

I verified all the URLs are valid with this script:

```
for d in $(cat che-theia-plugins.yaml | grep .vsix | sed -re "s@.+extension: @@" | tr -d "'" | sort -uV); do 
    echo -n "$d : "; stat=$(curl -sSI $d | grep HTTP/2); echo $stat
    if [[ $stat == *"404"* ]]; then echo "  ... not found!"; fi
done 
```

```
https://disaster37.github.io/vscode-plugins/4ops.terraform-0.2.2.vsix : HTTP/2 200 
https://disaster37.github.io/vscode-plugins/ivory-lab.jenkinsfile-support-1.1.0.vsix : HTTP/2 200 
https://github.com/DonJayamanne/gitHistoryVSCode/releases/download/v0.6.14/githistory-0.6.14.vsix : HTTP/2 302 
https://github.com/MicroShed/mp-starter-vscode-ext/releases/download/0.2.0/mp-starter-vscode-ext-0.2.0.vsix : HTTP/2 302 
https://github.com/PizzaFactory/xtend-ide-extensions/releases/download/v0.1.0/xtend-lang-0.1.0.vsix : HTTP/2 302 
https://github.com/PizzaFactory/xtext-ide-extensions/releases/download/v0.4.0/xtext-lang-0.4.0.vsix : HTTP/2 302 
https://github.com/SonarSource/sonarlint-vscode/releases/download/1.20.1/sonarlint-vscode-1.20.1.vsix : HTTP/2 302 
https://github.com/VSCodeVim/Vim/releases/download/v1.16.0/vim-1.16.0.vsix : HTTP/2 302 
https://github.com/bazelbuild/vscode-bazel/releases/download/0.3.0/vscode-bazel-0.3.0.vsix : HTTP/2 302 
https://github.com/che-incubator/vscode-emacs-friendly/releases/download/0.9.0/lfs.vscode-emacs-friendly-0.9.0.vsix : HTTP/2 302 
https://github.com/dart-code/flutter/releases/download/v3.14.1/flutter-3.14.1.vsix : HTTP/2 302 
https://github.com/eclipse/che-che4z-explorer-for-endevor/releases/download/1.0.0/explorer-for-endevor-1.0.0.vsix : HTTP/2 302 
https://github.com/eclipse/che-che4z-lsp-for-hlasm/releases/download/0.13.0/hlasm-language-support-0.13.0-alpine.vsix : HTTP/2 302 
https://github.com/eclipse/che-che4z/releases/download/v2.4.0/vscode-extension-for-zowe-1.16.0-che.vsix : HTTP/2 302 
https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.2.1/fabric8-analytics-0.2.1.vsix : HTTP/2 302 
https://github.com/gattytto/Dart-Code/releases/download/v3.15.0-che/dart-code-3.15.0-dev-realpathSync.vsix : HTTP/2 302 
https://github.com/golang/vscode-go/releases/download/v0.23.0/go-0.23.0.vsix : HTTP/2 302 
https://github.com/microsoft/vscode-pull-request-github/releases/download/0.21.1/vscode-pull-request-github-0.21.1.vsix : HTTP/2 302 
https://github.com/microsoft/vscode-python/releases/download/2020.7.94776/ms-python-release.vsix : HTTP/2 302 
https://github.com/pizzafactory-contorno/vscode-libra-move/releases/download/v0.0.10-ddc0d3d/vscode-libra-move-0.0.10.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/cdt-gdb-vscode-0.0.91-2cbbb8.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/cdt-vscode-0.0.7-75cf95.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/gitlens-10.2.1.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/java-0.63.0-2222.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/java-0.82.0-369.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/mta-vscode-extension-0.0.63-49.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/php-debug-1.13.0.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/project-initializer-0.0.10-582.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-apache-camel-0.1.5-1377.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-camelk-0.0.26-336.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-clangd-0.1.5-562d00.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-didact-0.4.0-309.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-eslint-2.1.1-1e15d3.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-intelephense-client-1.5.4.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-java-debug-0.26.0.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-kubernetes-tools-1.2.1.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-microprofile-0.1.1-48.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-proto3-0.4.2-c4d9ee.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-quarkus-1.5.0-324.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-quarkus-1.7.0-437.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-tekton-pipelines-0.2.0.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-wsdl2rest-0.0.11-106.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v069c634/vscode-xml-0.17.0.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v608e3a2/redhat.vscode-commons-021b0165bb5ba05e107ee7e31d1e59a7a73f473c.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v8130b13/vale-vscode-v0.14.2.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v2249123/asciidoctor-vscode-v2.8.7.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/vf707df2/shellcheck-v0.13.2.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/vf278912/vscode-markdown-mermaid-1.9.2.vsix : HTTP/2 302 
https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/vf278912/vscode-mermaid-syntax-highlight-d4247b5feadd92d429d69a6b511f5ed0e1011895.vsix : HTTP/2 302 
https://github.com/rogalmic/vscode-bash-debug/releases/download/untagged-78eaa7784342409ec2a3/bash-debug-0.3.9.vsix : HTTP/2 302 
https://github.com/rust-lang/vscode-rust/releases/download/v0.7.8/rust.vsix : HTTP/2 302 
https://github.com/scalameta/metals-vscode/releases/download/v1.11.1/scalameta.metals-1.11.1.vsix : HTTP/2 302 
https://github.com/scala/vscode-scala-syntax/releases/download/0.5.3/scala.vsix : HTTP/2 302 
https://github.com/vuejs/vetur/releases/download/v0.26.1/vetur-0.26.1.vsix : HTTP/2 302 
https://open-vsx.org/api/BroadcomMFD/ccf/0.4.0/file/BroadcomMFD.ccf-0.4.0.vsix : HTTP/2 302 
https://open-vsx.org/api/BroadcomMFD/cobol-language-support/0.19.0/file/BroadcomMFD.cobol-language-support-0.19.0.vsix : HTTP/2 302 
https://open-vsx.org/api/BroadcomMFD/debugger-for-mainframe/1.5.0/file/BroadcomMFD.debugger-for-mainframe-1.5.0.vsix : HTTP/2 302 
https://open-vsx.org/api/RandomChance/logstash/0.0.4/file/RandomChance.logstash-0.0.4.vsix : HTTP/2 302 
https://open-vsx.org/api/atlassian/atlascode/2.8.6/file/atlassian.atlascode-2.8.6.vsix : HTTP/2 302 
https://open-vsx.org/api/castwide/solargraph/0.23.0/file/castwide.solargraph-0.23.0.vsix : HTTP/2 302 
https://open-vsx.org/api/esbenp/prettier-vscode/5.8.0/file/esbenp.prettier-vscode-5.8.0.vsix : HTTP/2 302 
https://open-vsx.org/api/fbaligand/vscode-logstash-editor/1.1.3/file/fbaligand.vscode-logstash-editor-1.1.3.vsix : HTTP/2 302 
https://open-vsx.org/api/jebbs/plantuml/2.14.0/file/jebbs.plantuml-2.14.0.vsix : HTTP/2 302 
https://open-vsx.org/api/mads-hartmann/bash-ide-vscode/1.10.2/file/mads-hartmann.bash-ide-vscode-1.10.2.vsix : HTTP/2 302 
https://open-vsx.org/api/ms-vscode/js-debug/1.52.2/file/ms-vscode.js-debug-1.52.2.vsix : HTTP/2 302 
https://open-vsx.org/api/ms-vscode/node-debug2/1.42.5/file/ms-vscode.node-debug2-1.42.5.vsix : HTTP/2 302 
https://open-vsx.org/api/ms-vscode/node-debug/1.44.8/file/ms-vscode.node-debug-1.44.8.vsix : HTTP/2 302 
https://open-vsx.org/api/muhammad-sammy/csharp/1.23.16/file/muhammad-sammy.csharp-1.23.16.vsix : HTTP/2 302 
https://open-vsx.org/api/redhat/vscode-openshift-connector/0.2.9/file/redhat.vscode-openshift-connector-0.2.9.vsix : HTTP/2 302 
https://open-vsx.org/api/redhat/vscode-yaml/0.14.0/file/redhat.vscode-yaml-0.14.0.vsix : HTTP/2 302 
https://open-vsx.org/api/stylelint/vscode-stylelint/0.86.0/file/stylelint.vscode-stylelint-0.86.0.vsix : HTTP/2 302 
https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix : HTTP/2 302 
https://open-vsx.org/api/vscode/typescript-language-features/1.49.3/file/vscode.typescript-language-features-1.49.3.vsix : HTTP/2 302 

```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.