### PR TITLE
Update VS Code extension che4z-explorer-for-endevor to v1.1.0

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -630,8 +630,8 @@ plugins:
     extension: https://github.com/eclipse/che-che4z-lsp-for-hlasm/releases/download/0.13.0/hlasm-language-support-0.13.0-alpine.vsix
   - repository:
       url: 'https://github.com/eclipse/che-che4z-explorer-for-endevor'
-      revision: 1.0.1
-    extension: https://github.com/eclipse/che-che4z-explorer-for-endevor/releases/download/1.0.1/explorer-for-endevor-1.0.1.vsix
+      revision: 1.1.0
+    extension: https://github.com/eclipse/che-che4z-explorer-for-endevor/releases/download/1.1.0/explorer-for-endevor-1.1.0.vsix
   - repository:
       url: 'https://github.com/zxh0/vscode-proto3'
       revision: c4d9eeb54294e3cee86254261edf036901f29dec


### PR DESCRIPTION
Signed-off-by: Roman Kupriyanov <roman.kupriyanov@broadcom.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

Updates the version Explorer for Endevor in the registry.

Explorer for Endevor v1.1.0 change log:

- Added the generate an element with copyback and generate with no source features.
- Added the Signout-overriding functionality to the generate an element feature.
- The **Remove profile** context menu item is changed to **Hide profile** to avoid confusion.
- Now multiple notification messages are displayed in one message upon successful element generation.
- Changed the VS Code version requirement. Ensure that you use VS Code 1.58.0 or higher.
- Fixed an issue with the signout error recovery attempt when an element is edited and uploaded into a different location.
- Fixed an issue that prevented the extension from updating an Endevor map tree after uploading the edited element into a new location.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
