### PR TITLE
fix: replace relative:extension with internal URL of plugin registry

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -23,6 +23,7 @@ set -e
 REGISTRY=${CHE_SIDECAR_CONTAINERS_REGISTRY_URL}
 ORGANIZATION=${CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION}
 TAG=${CHE_SIDECAR_CONTAINERS_REGISTRY_TAG}
+INTERNAL_URL=${CHE_PLUGIN_REGISTRY_INTERNAL_URL}
 
 DEFAULT_METAS_DIR="/var/www/html/v3"
 METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
@@ -43,6 +44,8 @@ function run_main() {
     extract_and_use_related_images_env_variables_with_image_digest_info
 
     update_container_image_references
+
+    update_extension_vsx_references
 
     exec "${@}"
 
@@ -139,7 +142,15 @@ function update_container_image_references() {
         < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     done
+}
 
+function update_extension_vsx_references() {
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml' -o -name 'che-theia-plugin.yaml')
+    if [ -n "$INTERNAL_URL" ]; then
+        INTERNAL_URL=${INTERNAL_URL%/}
+        echo "Updating relative:extension in files to ${INTERNAL_URL}"
+        sed -i "s|relative:extension|${INTERNAL_URL}|" "${metas[@]}"
+    fi
 }
 
 # do not execute the main function in unit tests

--- a/build/dockerfiles/test_entrypoint.sh
+++ b/build/dockerfiles/test_entrypoint.sh
@@ -776,3 +776,86 @@ source "${script_dir}/entrypoint.sh"
 extract_and_use_related_images_env_variables_with_image_digest_info
 
 assertFileContentEquals "${METAS_DIR}/che-theia-plugin.yaml" "${expected_cheTheiaPluginYaml}"
+
+#################################################################
+initTest "Should replace relative:extension with internal URL in che-theia-plugin.yaml "
+
+cheTheiaPluginYaml=$(cat <<-END
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java
+  publisher: redhat
+  name: java
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+  repository: https://github.com/redhat-developer/vscode-java
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  name: vscode-java
+  memoryLimit: 1500Mi
+  memoryRequest: 20Mi
+  cpuLimit: 800m
+  cpuRequest: 30m
+  volumeMounts:
+    - name: m2
+      path: /home/theia/.m2
+  image: quay.io/eclipse/che-plugin-sidecar:java-23e57d6
+preferences:
+  java.server.launchMode: Standard
+dependencies:
+  - vscjava/vscode-java-debug
+  - vscjava/vscode-java-test
+extensions:
+  - relative:extension/resources/github_com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7_44-che-assets/java-0.82.0-369.vsix
+END
+)
+expected_cheTheiaPluginYaml=$(cat <<-END
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java
+  publisher: redhat
+  name: java
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+  repository: https://github.com/redhat-developer/vscode-java
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  name: vscode-java
+  memoryLimit: 1500Mi
+  memoryRequest: 20Mi
+  cpuLimit: 800m
+  cpuRequest: 30m
+  volumeMounts:
+    - name: m2
+      path: /home/theia/.m2
+  image: quay.io/eclipse/che-plugin-sidecar:java-23e57d6
+preferences:
+  java.server.launchMode: Standard
+dependencies:
+  - vscjava/vscode-java-debug
+  - vscjava/vscode-java-test
+extensions:
+  - http://che-plugin-registry/v3/resources/github_com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7_44-che-assets/java-0.82.0-369.vsix
+END
+)
+
+echo "$cheTheiaPluginYaml" > "${METAS_DIR}/che-theia-plugin.yaml"
+
+export CHE_PLUGIN_REGISTRY_INTERNAL_URL=http://che-plugin-registry/v3
+
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+update_extension_vsx_references
+assertFileContentEquals "${METAS_DIR}/che-theia-plugin.yaml" "${expected_cheTheiaPluginYaml}"


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
In case when the plugin registry was built on offline mode, all vsx files are located inside the image.
che-theia-plugin.yaml should use CHE_PLUGIN_REGISTRY_INTERNAL_URL to reference to vsx files

This PR replaces `relative:extension` with CHE_PLUGIN_REGISTRY_INTERNAL_URL in che-theia-plugin.yaml files

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21585


### How to test this PR?
1. Build plugin registry with --offline attribute
2. Use resulted image in your cluster by pointing it in the CRD:
```
    pluginRegistry:
      deployment:
        containers:
          - image: 'vsvydenko/che-plugin-registry:next'
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
