### PR TITLE
chore: update to latest python from...

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -128,7 +128,7 @@ plugins:
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-intelephense-client-1.5.4.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode-python'
-      revision: 2020.7.94776
+      revision: 2022.10.1
     featured: true
     sidecar:
       directory: python
@@ -140,7 +140,7 @@ plugins:
       volumeMounts:
         - name: venv
           path: /home/theia/.venv
-    extension: https://github.com/microsoft/vscode-python/releases/download/2020.7.94776/ms-python-release.vsix
+    extension: https://open-vsx.org/api/ms-python/python/2022.10.1/file/ms-python.python-2022.10.1.vsix
   - repository:
       url: 'https://github.com/asciidoctor/asciidoctor-vscode'
       revision: v2.8.7


### PR DESCRIPTION
### What does this PR do?

chore: update to latest python from https://open-vsx.org/api/ms-python/python/2022.10.1/file/ms-python.python-2022.10.1.vsix

Change-Id: I395f0e0d4991766533d42747d9c76eb124308f99
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

upstream equivalent change to https://github.com/redhat-developer/devspaces/pull/774 for various issues including:
* [CRW-2619](https://issues.redhat.com/browse/CRW-2619) udi: python :: migrate to cachito
* [CRW-2659](https://issues.redhat.com/browse/CRW-2659) Upgrade the Python plugin for CRW
* [CRW-1927](https://issues.redhat.com/browse/CRW-1927) [python] Option to run a single test through Test Explorer does not work

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.