### PR TITLE
fix: update chectl deploy command

### DIFF
--- a/.ci/openshift-ci/common-functions.sh
+++ b/.ci/openshift-ci/common-functions.sh
@@ -75,7 +75,7 @@ END
 }
 
 deployChe() {
-  chectl server:deploy --che-operator-cr-patch-yaml=custom-resources.yaml --platform=openshift --installer=operator --batch
+  chectl server:deploy --che-operator-cr-patch-yaml=custom-resources.yaml --platform=openshift --batch
 }
 
 patchTestPodConfig(){


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Remove `installer=operator` parameter form the chectl command, it's needed to fix tests on OS