### PR TITLE
feat: update fabric8-analytics to 0.3.6

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -272,7 +272,7 @@ plugins:
         - vscjava/vscode-java-test
   - repository:
       url: 'https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension'
-      revision: 0.2.1
+      revision: 0.3.6
     aliases:
       - redhat/dependency-analytics
     sidecar:
@@ -282,7 +282,7 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.2.1/fabric8-analytics-0.2.1.vsix
+    extension: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.3.6/fabric8-analytics-0.3.6.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-tekton'
       revision: v0.2.0


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Updates fabric8-analytics-vscode extension to 0.3.6

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
[screencast-nimbus-capture-2022.08.10-22_31_27.webm](https://user-images.githubusercontent.com/1271546/184678930-e284d50f-dff9-46d0-9d6e-372f460869a0.webm)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21372

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. deploy che
`chectl server:deploy --che-operator-cr-patch-yaml=custom-resources.yaml --platform=openshift`
where the content of **custom-resources.yaml** is:
```
apiVersion: org.eclipse.che/v2
spec:
  components:
    pluginRegistry:
      deployment:
        containers:
          - image: vsvydenko/che-plugin-registry:next
```

2. Start a Python workspace and install fabric8-analytics plugin:
![screenshot-eclipse-che apps ci-ln-m7z4m6k-72292 origin-ci-int-gce dev rhcloud com-2022 08 15-20_44_13](https://user-images.githubusercontent.com/1271546/184687576-060af6aa-b4f1-4e27-ba5a-9115c7437d87.png)

3. Test fabric8-analytics plugin

**_NOTES_**:
_The plugin has a problem in Che-Theia when generate the report by using project tree at the first time. To workaround this problem try to generate the report by using a command at the first time: click F1 and select Dependency Analytics: Stack Report... Then it's possible to execute command from the project tree._
![Screenshot from 2022-08-15 20-45-13](https://user-images.githubusercontent.com/1271546/184688876-aae1bb71-3f4d-4fcd-90f8-2a676d8928f7.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
