### PR TITLE
fix: update file permissions

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -69,6 +69,8 @@ COPY README.md .htaccess /mnt/rootfs/var/www/html/
 COPY output/v3 /mnt/rootfs/var/www/html/v3
 COPY v3/plugins/ /mnt/rootfs/var/www/html/v3/plugins/
 COPY v3/images/*.png /mnt/rootfs/var/www/html/v3/images/
+# apply permissions to later change these files (entrypoint update_extension_vsx_references)
+RUN chmod g+rwx -R /mnt/rootfs/var/www/html/v3
 
 # Use scratch image and then copy ubi fs
 FROM scratch


### PR DESCRIPTION
### What does this PR do?
There is a need to apply sed operations on files https://github.com/eclipse-che/che-plugin-registry/pull/1351
for INTERNAL_URL so we require write permissions on these files

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/21641


### How to test this PR?

Create a file named `/tmp/patch.yaml`
```yaml
spec:
  components:
    pluginRegistry:
      deployment:
        containers:
          - image: 'quay.io/fbenoit/che-plugin-registry:21641-2022-19-08'
```

deploy with
```bash
chectl server:deploy --platform=openshift --che-operator-cr-patch-yaml=/tmp/patch.yaml
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I0c534daec82111a63a2346fa40d34726908f8d16
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
