### PR TITLE
chore: Wait until PostgreSQL and VSX registry is ready

### DIFF
--- a/build/dockerfiles/start-services.sh
+++ b/build/dockerfiles/start-services.sh
@@ -8,12 +8,12 @@ pushd /var/lib/pgsql || return
 /usr/pgsql-14/bin/postgres &
 # wait that postgresql is ready
 printf "Waiting that postgresql is ready"
-timeout 15 bash -c "until /usr/pgsql-14/bin/pg_isready -h 127.0.0.1 -p 5432 -U postgres -q; do printf '.'; sleep 1; done"
+timeout 0 bash -c "until /usr/pgsql-14/bin/pg_isready -h 127.0.0.1 -p 5432 -U postgres -q; do printf '.'; sleep 1; done"
 echo "Database is ready"
 
 # start openvsx
 pushd /openvsx-server || return
 ./run-server.sh &
 printf "Waiting that openvsx is ready"
-timeout 200 bash -c "until curl --output /dev/null --head --silent --fail http://localhost:9000/user; do printf '.'; sleep 1; done"
+timeout 0 bash -c "until curl --output /dev/null --head --silent --fail http://localhost:9000/user; do printf '.'; sleep 1; done"
 printf "Openvsx is ready"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* remove 15s timeout to wait until PostgreSQL is ready
* remove 200s timeout to wait until VSX registry is ready

Is save enough to remove those timeout since plugin-registry container will be automatically restarted once liveness probe failed (300s).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21666

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
