### PR TITLE
chore: use name instead of displayName in generated editor devfile

### DIFF
--- a/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
+++ b/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
@@ -90,11 +90,19 @@ export class MetaYamlToDevfileYaml {
       return;
     }
 
+    let name = '';
+    if (metaYaml.name) {
+      name = metaYaml.name;
+      name = name.replace(/\//gi, '-');
+    } else {
+      name = metaYaml.displayName;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const devfileYaml: any = {
       schemaVersion: '2.1.0',
       metadata: {
-        name: metaYaml.displayName,
+        name: name,
       },
     };
 

--- a/tools/build/tests/_data/meta/che-theia-meta.yaml
+++ b/tools/build/tests/_data/meta/che-theia-meta.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 publisher: eclipse
-name: che-theia
+name: che/theia/next
 version: next
 type: Che Editor
 displayName: theia-ide

--- a/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
+++ b/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
@@ -37,7 +37,7 @@ describe('Test MetaYamlToDevfileYaml', () => {
     const metaYaml = jsYaml.load(metaYamlContent);
     const devfileYaml = metaYamlToDevfileYaml.convert(metaYaml);
     expect(devfileYaml.schemaVersion).toBe('2.1.0');
-    expect(devfileYaml.metadata?.name).toBe('Che machine-exec Service');
+    expect(devfileYaml.metadata?.name).toBe('che-machine-exec-plugin');
     expect(devfileYaml.components).toBeDefined();
     expect(devfileYaml.components?.length).toBe(1);
     const component = devfileYaml.components[0];
@@ -63,7 +63,7 @@ describe('Test MetaYamlToDevfileYaml', () => {
     const metaYaml = jsYaml.load(metaYamlContent);
     const devfileYaml = metaYamlToDevfileYaml.convert(metaYaml);
     expect(devfileYaml.schemaVersion).toBe('2.1.0');
-    expect(devfileYaml.metadata?.name).toBe('theia-ide');
+    expect(devfileYaml.metadata?.name).toBe('che-theia-next');
     expect(devfileYaml.components).toBeDefined();
     expect(devfileYaml.components?.length).toBe(6);
     const theiaIdeComponent = devfileYaml.components[0];
@@ -149,7 +149,7 @@ describe('Test MetaYamlToDevfileYaml', () => {
     const metaYaml = jsYaml.load(metaYamlContent);
     const devfileYaml = metaYamlToDevfileYaml.convert(metaYaml);
     expect(devfileYaml.schemaVersion).toBe('2.1.0');
-    expect(devfileYaml.metadata?.name).toBe('no-container');
+    expect(devfileYaml.metadata?.name).toBe('che-theia');
     expect(devfileYaml.components).toBeDefined();
     expect(devfileYaml.components?.length).toBe(1);
     const component = devfileYaml.components[0];


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Use `metadata.name` instead of `metadata.displayName` to generate devfile.yaml.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21704

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
