### PR TITLE
chore: add container-contribution attribute for editors

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -112,6 +112,26 @@ editors:
             - exposedPort: 13131
             - exposedPort: 13132
             - exposedPort: 13133
+      - name: theia-ide-contributions
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          args:
+            - sh
+            - '-c'
+            - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins/sidecars/tools
+          memoryLimit: 512Mi
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: remote-endpoint
+              path: /remote-endpoint
+          image: "quay.io/devfile/universal-developer-image:ubi8-13008af"
       - name: plugins
         volume: {}
       - name: theia-local
@@ -337,7 +357,7 @@ editors:
           cpuRequest: 30m
       - name: che-code-runtime-description
         container:
-          image: 'quay.io/devfile/universal-developer-image:ubi8-770ea4a'
+          image: 'quay.io/devfile/universal-developer-image:ubi8-13008af'
           memoryLimit: 1024Mi
           memoryRequest: 256Mi
           cpuLimit: 500m
@@ -383,6 +403,7 @@ editors:
         attributes:
           app.kubernetes.io/component: che-code-runtime
           app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/container-contribution: true
       - name: checode
         volume: {}
   - schemaVersion: 2.1.0
@@ -419,7 +440,7 @@ editors:
           cpuRequest: 30m
       - name: che-code-runtime-description
         container:
-          image: 'quay.io/devfile/universal-developer-image:ubi8-770ea4a'
+          image: 'quay.io/devfile/universal-developer-image:ubi8-13008af'
           memoryLimit: 1024Mi
           memoryRequest: 256Mi
           cpuLimit: 500m
@@ -465,6 +486,7 @@ editors:
         attributes:
           app.kubernetes.io/component: che-code-runtime
           app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/container-contribution: true
       - name: checode
         volume: {}
   - schemaVersion: 2.1.0


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds container-contribution attribute for VS Code and Theia editors.

**_NOTE_: The IDEA editor wasn't changed**

Resulted editors devfiles:

<details>
  <summary>VS Code</summary>

```yaml
schemaVersion: 2.1.0
metadata:
  name: che-code
commands:
  - id: init-container-command
    apply:
      component: che-code-injector
events:
  preStart:
    - init-container-command
components:
  - name: che-code-runtime-description
    container:
      image: quay.io/devfile/universal-developer-image:ubi8-13008af
      command:
        - /checode/entrypoint-volume.sh
      volumeMounts:
        - name: checode
          path: /checode
      memoryLimit: 1024Mi
      memoryRequest: 256Mi
      cpuLimit: 500m
      cpuRequest: 30m
      endpoints:
        - name: che-code
          attributes:
            type: main
            cookiesAuthEnabled: true
            discoverable: false
            urlRewriteSupported: true
          targetPort: 3100
          exposure: public
          path: '?tkn=eclipse-che'
          secure: false
          protocol: https
        - name: code-redirect-1
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13131
          exposure: public
          protocol: http
        - name: code-redirect-2
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13132
          exposure: public
          protocol: http
        - name: code-redirect-3
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13133
          exposure: public
          protocol: http
    attributes:
      app.kubernetes.io/component: che-code-runtime
      app.kubernetes.io/part-of: che-code.eclipse.org
      controller.devfile.io/container-contribution: true
  - name: checode
    volume: {}
  - name: che-code-injector
    container:
      image: quay.io/che-incubator/che-code:insiders
      command:
        - /entrypoint-init-container.sh
      volumeMounts:
        - name: checode
          path: /checode
      memoryLimit: 128Mi
      memoryRequest: 32Mi
      cpuLimit: 500m
      cpuRequest: 30m
```
</details>

<details>
  <summary>Theia</summary>

```yaml
schemaVersion: 2.1.0
metadata:
  name: che-theia
commands:
  - id: init-container-command
    apply:
      component: remote-runtime-injector
events:
  preStart:
    - init-container-command
components:
  - name: theia-ide
    container:
      image: quay.io/eclipse/che-theia:7.57.0
      env:
        - name: THEIA_PLUGINS
          value: local-dir:///plugins
        - name: HOSTED_PLUGIN_HOSTNAME
          value: 0.0.0.0
        - name: HOSTED_PLUGIN_PORT
          value: '3130'
        - name: THEIA_HOST
          value: 127.0.0.1
      volumeMounts:
        - name: plugins
          path: /plugins
        - name: theia-local
          path: /home/theia/.theia
      mountSources: true
      memoryLimit: 512M
      cpuLimit: 1500m
      cpuRequest: 100m
      endpoints:
        - name: theia
          attributes:
            type: main
            cookiesAuthEnabled: true
            discoverable: false
            urlRewriteSupported: true
          targetPort: 3100
          exposure: public
          secure: false
          protocol: https
        - name: webviews
          attributes:
            type: webview
            cookiesAuthEnabled: true
            discoverable: false
            unique: true
            urlRewriteSupported: true
          targetPort: 3100
          exposure: public
          secure: false
          protocol: https
        - name: mini-browser
          attributes:
            type: mini-browser
            cookiesAuthEnabled: true
            discoverable: false
            unique: true
            urlRewriteSupported: true
          targetPort: 3100
          exposure: public
          secure: false
          protocol: https
        - name: theia-dev
          attributes:
            type: ide-dev
            discoverable: false
            urlRewriteSupported: true
          targetPort: 3130
          exposure: public
          protocol: http
        - name: theia-redirect-1
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13131
          exposure: public
          protocol: http
        - name: theia-redirect-2
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13132
          exposure: public
          protocol: http
        - name: theia-redirect-3
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13133
          exposure: public
          protocol: http
        - name: terminal
          attributes:
            type: collocated-terminal
            discoverable: false
            cookiesAuthEnabled: true
            urlRewriteSupported: true
          targetPort: 3333
          exposure: public
          secure: false
          protocol: wss
    attributes:
      app.kubernetes.io/component: che-theia
      app.kubernetes.io/part-of: che-theia.eclipse.org
  - name: plugins
    volume: {}
  - name: theia-local
    volume: {}
  - name: theia-ide-contributions
    container:
      image: quay.io/devfile/universal-developer-image:ubi8-13008af
      args:
        - sh
        - '-c'
        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
      env:
        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
          value: /remote-endpoint/plugin-remote-endpoint
        - name: THEIA_PLUGINS
          value: local-dir:///plugins/sidecars/tools
      volumeMounts:
        - name: plugins
          path: /plugins
        - name: remote-endpoint
          path: /remote-endpoint
      memoryLimit: 512Mi
    attributes:
      controller.devfile.io/container-contribution: true
  - name: remote-endpoint
    volume:
      ephemeral: true
  - name: che-machine-exec
    container:
      image: quay.io/eclipse/che-machine-exec:7.57.0
      command:
        - /go/bin/che-machine-exec
        - '--url'
        - 127.0.0.1:3333
      memoryLimit: 128Mi
      memoryRequest: 32Mi
      cpuLimit: 500m
      cpuRequest: 30m
    attributes:
      app.kubernetes.io/component: machine-exec
      app.kubernetes.io/part-of: che-theia.eclipse.org
  - name: remote-runtime-injector
    container:
      image: quay.io/eclipse/che-theia-endpoint-runtime-binary:7.57.0
      env:
        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
          value: /remote-endpoint/plugin-remote-endpoint
        - name: REMOTE_ENDPOINT_VOLUME_NAME
          value: remote-endpoint
      volumeMounts:
        - name: plugins
          path: /plugins
        - name: remote-endpoint
          path: /remote-endpoint
    attributes:
      app.kubernetes.io/component: remote-runtime-injector
      app.kubernetes.io/part-of: che-theia.eclipse.org
```
</details>

<details>
  <summary>IntelliJ</summary>

```yaml
schemaVersion: 2.1.0
metadata:
  name: che-idea
commands:
  - id: init-container-command
    apply:
      component: che-idea-injector
events:
  preStart:
    - init-container-command
components:
  - name: che-idea-runtime-description
    container:
      image: quay.io/devfile/universal-developer-image:ubi8-9436df2
      command:
        - /projector/entrypoint-volume.sh
      env:
        - name: PROJECTOR_ASSEMBLY_DIR
          value: /projector
        - name: PROJECTOR_CONFIG_DIR
          value: /home/user/.jetbrains
      volumeMounts:
        - name: projector-volume
          path: /projector
        - name: projector-configuration
          path: /home/user/.jetbrains
        - name: projector-java-configuration
          path: /home/user/.java
      memoryLimit: 6144Mi
      memoryRequest: 2048Mi
      cpuLimit: 2000m
      cpuRequest: 1500m
      endpoints:
        - name: intellij
          attributes:
            type: main
            cookiesAuthEnabled: true
            discoverable: false
            urlRewriteSupported: true
            secure: false
          targetPort: 8887
          exposure: public
          path: /?backgroundColor=434343&wss
          protocol: http
        - name: intellij-redirect-1
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13131
          exposure: public
          protocol: http
        - name: intellij-redirect-2
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13132
          exposure: public
          protocol: http
        - name: intellij-redirect-3
          attributes:
            discoverable: false
            urlRewriteSupported: true
          targetPort: 13133
          exposure: public
          protocol: http
    attributes:
      app.kubernetes.io/component: che-idea-injector
      app.kubernetes.io/part-of: che-idea.eclipse.org
  - name: projector-volume
    volume: {}
  - name: projector-configuration
    volume: {}
  - name: projector-java-configuration
    volume: {}
  - name: che-idea-injector
    container:
      image: quay.io/che-incubator/che-idea:next
      command:
        - /projector/entrypoint-init-container.sh
      env:
        - name: PROJECTOR_VOLUME_MOUNT
          value: /projector-volume
        - name: PROJECTOR_ASSEMBLY_DIR
          value: /projector
      volumeMounts:
        - name: projector-volume
          path: /projector-volume
      memoryLimit: 128Mi
      memoryRequest: 32Mi
      cpuLimit: 500m
      cpuRequest: 30m
```
</details>

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

https://github.com/eclipse/che/issues/21739

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Create a DevWorkspace by 
`kubectl apply -f https://gist.githubusercontent.com/svor/c2982cd08c41153c45a4d38dbb27b1b0/raw/07da742f0ce10befe65a06a7df928d9115e704eb/che-theia-ws-contribution.yaml`

or

`kubectl apply -f https://gist.githubusercontent.com/svor/d87dc2532a0e5ff8305f9c69af6b6df0/raw/5bd192e47ab1ce6fb444a2c921294981f5e9aa1e/che-code-ws-contribution.yaml --namespace=che-kube-admin-che-6eil2f`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
