### PR TITLE
Increase the size of the HTTP request header allowed from the client to 32 KB

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -56,6 +56,7 @@ RUN sed -i /mnt/rootfs/etc/httpd/conf/httpd.conf \
     -e "s,logs/error_log,/dev/stderr," \
     -e "s,logs/access_log,/dev/stdout," \
     -e "s,AllowOverride None,AllowOverride All," && \
+    echo "LimitRequestFieldSize 32768" >> /mnt/rootfs/etc/httpd/conf/httpd.conf && \
     chmod a+rwX /mnt/rootfs/etc/httpd/conf /mnt/rootfs/etc/httpd/conf.d /mnt/rootfs/run/httpd /mnt/rootfs/etc/httpd/logs/
 
 STOPSIGNAL SIGWINCH


### PR DESCRIPTION
### What does this PR do?
Apache HTTP Server restricts the size of the HTTP request header allowed from the client. Default value is set to 8192 (8 KB). In order to avoid request blocking by this limitation, `httpd.conf` has been adjusted to set 32768 (32 KB).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
The size of the HTTP request header allowed from the client is limited to 32 KB (not to 8 KB by default) after this change.
You can sum cookie size on screenshot below - about 16 KB. And we got success response.
![image](https://user-images.githubusercontent.com/63723184/210912400-e934c8b6-2c47-4d27-818b-702040bee666.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21917

### How to test this PR?
1. Deploy Che with `docker.io/karatkep/che-plugin-registry:hs-32kb` as plugin-registry image.
2. Call any plugin-registry URL, for example: GET /plugin-registry/v3/plugins/che-incubator/che-code/insiders/devfile.yaml. Please see screenshot above.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
