### PR TITLE
chore: increase memoryLimit for che-code-injector component

### DIFF
--- a/.github/workflows/image-build-pr-check.yml
+++ b/.github/workflows/image-build-pr-check.yml
@@ -61,7 +61,7 @@ jobs:
         docker cp pluginRegistry:${EXPORTED_FOLDER} root-dir/v3
         docker rm -f pluginRegistry
         cp root-dir/v3/plugins/index.json root-dir/index.json
-        tar zcvf content-${{matrix.dist}}.tgz -C root-dir .
+        tar zcvf content.tgz -C root-dir .
     - uses: actions/upload-artifact@v3
       with:
         name: plugin-registry-content

--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -355,7 +355,7 @@ editors:
           volumeMounts:
             - name: checode
               path: /checode
-          memoryLimit: 128Mi
+          memoryLimit: 256Mi
           memoryRequest: 32Mi
           cpuLimit: 500m
           cpuRequest: 30m
@@ -438,7 +438,7 @@ editors:
           volumeMounts:
             - name: checode
               path: /checode
-          memoryLimit: 128Mi
+          memoryLimit: 256Mi
           memoryRequest: 32Mi
           cpuLimit: 500m
           cpuRequest: 30m


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Increase memoryLimit for che-code-injector component to 256Mi
- Fix an action to publish PR content to surge

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21719

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Start a workspace by using factory:
https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#/https://github.com/che-samples/web-nodejs-sample/tree/devfilev2?che-editor=https://gist.githubusercontent.com/svor/55d4b83ee3a2f1df5555b8a44c4a539a/raw/43ebe852bdd2338edcce683c63437613cf2ede20/code.yaml

Check that the che-code-injector init container was not restarted:
![screenshot-console-openshift-console apps che-dev x6e0 p1 openshiftapps com-2023 01 26-20_05_43](https://user-images.githubusercontent.com/1271546/214914938-898c8a4d-34c0-4ad1-865c-51207104d180.png)

![screenshot-console-openshift-console apps che-dev x6e0 p1 openshiftapps com-2023 01 26-20_04_34](https://user-images.githubusercontent.com/1271546/214914957-0949df53-59d4-4b08-8cdf-c5f42b5f6587.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
