### PR TITLE
fix: mark che-pycharm-runtime-description component as container-contribution

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -769,8 +769,9 @@ editors:
                 discoverable: false
                 urlRewriteSupported: false
         attributes:
-          app.kubernetes.io/component: che-pycharm-injector
+          app.kubernetes.io/component: che-pycharm-runtime
           app.kubernetes.io/part-of: che-pycharm.eclipse.org
+          controller.devfile.io/container-contribution: true
       - name: projector-volume
         volume: {}
       - name: projector-configuration
@@ -869,8 +870,9 @@ editors:
                 discoverable: false
                 urlRewriteSupported: false
         attributes:
-          app.kubernetes.io/component: che-pycharm-injector
+          app.kubernetes.io/component: che-pycharm-runtime
           app.kubernetes.io/part-of: che-pycharm.eclipse.org
+          controller.devfile.io/container-contribution: true
       - name: projector-volume
         volume: {}
       - name: projector-configuration


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
1. Marks `che-pycharm-runtime-description` component as container contribution.
2. Replaces `app.kubernetes.io/component: che-pycharm-injector` on `app.kubernetes.io/component: che-pycharm-runtime` to be consistent with `che-code` where everything works without issues

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21878

Depends on https://github.com/eclipse/che/issues/21738

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
