### PR TITLE
feat: Use post-start event to start VS Code

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -344,9 +344,15 @@ editors:
       - id: init-container-command
         apply:
           component: che-code-injector
+      - id: init-che-code-command
+        exec:
+          component: che-code-runtime-description
+          commandLine: 'nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt 2>&1 &'
     events:
       preStart:
         - init-container-command
+      postStart:
+        - init-che-code-command
     components:
       - name: che-code-injector
         container:
@@ -366,8 +372,6 @@ editors:
           memoryRequest: 256Mi
           cpuLimit: 500m
           cpuRequest: 30m
-          command:
-            - /checode/entrypoint-volume.sh
           volumeMounts:
             - name: checode
               path: /checode
@@ -426,9 +430,15 @@ editors:
       - id: init-container-command
         apply:
           component: che-code-injector
+      - id: init-che-code-command
+        exec:
+          component: che-code-runtime-description
+          commandLine: 'nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt 2>&1 &'
     events:
       preStart:
         - init-container-command
+      postStart:
+        - init-che-code-command
     components:
       - name: che-code-injector
         container:
@@ -448,8 +458,6 @@ editors:
           memoryRequest: 256Mi
           cpuLimit: 500m
           cpuRequest: 30m
-          command:
-            - /checode/entrypoint-volume.sh
           volumeMounts:
             - name: checode
               path: /checode


### PR DESCRIPTION
depends on: https://github.com/eclipse-che/che-plugin-registry/pull/1613

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Use post-start event instead of command to start VS Code

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21879

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

We should check that VS Code starts successfully after resolving https://github.com/devfile/devworkspace-operator/issues/1029 

I tested it like:
- go to the dashboard => `Create Workspace` page
- put https://github.com/RomanNikitenko/devfile-stacks-nodejs-react/tree/post-start to the `Git Repo URL`
- click `Create & Open` button

[The sample](https://github.com/RomanNikitenko/devfile-stacks-nodejs-react/tree/post-start) contains [the corresponding changes](https://github.com/RomanNikitenko/devfile-stacks-nodejs-react/commit/1a5d1ab1eb84e988727cd8df4d10afc10db080a4) for the editor description.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
