### PR TITLE
chore: download vsix by an universal link

### DIFF
--- a/build/dockerfiles/import-vsix.sh
+++ b/build/dockerfiles/import-vsix.sh
@@ -66,10 +66,10 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
         
         # extract the download link from the json metadata
         vsixDownloadLink=$(echo "${vsixMetadata}" | jq -r '.files.download')
-        # get linux-x64 download link
-        vsixLinux64DownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."linux-x64"')
-        if [[ $vsixLinux64DownloadLink != null ]]; then
-            vsixDownloadLink=$vsixLinux64DownloadLink
+        # get universal download link
+        vsixUniversalDownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."universal"')
+        if [[ $vsixUniversalDownloadLink != null ]]; then
+            vsixDownloadLink=$vsixUniversalDownloadLink
         fi
     fi
 

--- a/openvsx-sync.json
+++ b/openvsx-sync.json
@@ -61,7 +61,7 @@
     },
     {
         "id": "redhat.java",
-        "version": "1.12.0"
+        "version": "1.14.0"
     },
     {
         "id": "vscjava.vscode-java-debug"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
- Upgrade redhat.java extension to 1.14.0 version fro local registry
- Most of the VS Code extensions provide only one link for downloading, for example [ms-python.python](https://open-vsx.org/api/ms-python/python/). 
But there are extensions with several links for downloading (depending on a target platform), for example [redhat.java](https://open-vsx.org/api/redhat/java/1.14.0):

```json
"downloads": {
    "linux-x64": "https://open-vsx.org/api/redhat/java/linux-x64/1.14.0/file/redhat.java-1.14.0@linux-x64.vsix",
    "win32-x64": "https://open-vsx.org/api/redhat/java/win32-x64/1.14.0/file/redhat.java-1.14.0@win32-x64.vsix",
    "darwin-x64": "https://open-vsx.org/api/redhat/java/darwin-x64/1.14.0/file/redhat.java-1.14.0@darwin-x64.vsix",
    "darwin-arm64": "https://open-vsx.org/api/redhat/java/darwin-arm64/1.14.0/file/redhat.java-1.14.0@darwin-arm64.vsix",
    "universal": "https://open-vsx.org/api/redhat/java/1.14.0/file/redhat.java-1.14.0.vsix",
    "linux-arm64": "https://open-vsx.org/api/redhat/java/linux-arm64/1.14.0/file/redhat.java-1.14.0@linux-arm64.vsix"
}
```

we have to take a link for the universal target platform, the downloaded extension from this link should work in all platforms.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3624

