### PR TITLE
fix: do copy yarn.lock in PR branch

### DIFF
--- a/.github/workflows/regen-yarn-lock-and-copy.yml
+++ b/.github/workflows/regen-yarn-lock-and-copy.yml
@@ -17,13 +17,14 @@ name: Copy yarn.lock to tools/build/
 on:
   push:
     branches:
-      - main
+      - '*/*'
+      - '!main'
     paths:
       - 'yarn.lock'
       - '!tools/build/yarn.lock'
 
 jobs:
-  build:
+  copy-yarn-lock:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -39,7 +40,6 @@ jobs:
           git config --global user.name "Che bot"
       - name: Commit changes
         run: |
-          git pull
           git add tools/build/yarn.lock
           git commit --amend --no-edit --signoff
           git push || true


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Copy yarn.lock into tools/build/ in PR branch
