### PR TITLE
chore: find a first stable and compatible version of the extension to include it into the embedded plugin registry

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -62,6 +62,7 @@ RUN sed -i /mnt/rootfs/etc/httpd/conf/httpd.conf \
 STOPSIGNAL SIGWINCH
 
 RUN mkdir -m 777 /mnt/rootfs/var/www/html/v3
+COPY /VERSION /mnt/rootfs/
 COPY /build/dockerfiles/*.sh /mnt/rootfs/
 COPY /openvsx-sync.json /mnt/rootfs/
 RUN chmod 755 /mnt/rootfs/*.sh

--- a/openvsx-sync.json
+++ b/openvsx-sync.json
@@ -60,8 +60,7 @@
         "id": "ms-kubernetes-tools.vscode-kubernetes-tools"
     },
     {
-        "id": "redhat.java",
-        "version": "1.14.0"
+        "id": "redhat.java"
     },
     {
         "id": "vscjava.vscode-java-debug"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Finds latest and stable version for each extension that is going to be included into the embedded plugin registry.
Also it checks that vscode engine version in the extension is compatible with Che Code version.


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4165
https://issues.redhat.com/browse/CRW-4336

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Run che with current version of plugin registry
- Activate embedded plugin registry
- Check that latest stable version of vscode-java extension (redhat.java-1.18.0) is available and it's possible to install it

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
