### PR TITLE
chore: upgrade ghcr.io/eclipse/openvsx-server image and depended tools

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,9 +12,7 @@
 #
 
 # OpenVSX
-#FROM ghcr.io/eclipse/openvsx-server:72706d1 AS openvsx-server
-# fix https://github.com/eclipse/openvsx/pull/499 for https://github.com/eclipse/openvsx/issues/498
-FROM ghcr.io/eclipse/openvsx-server:f061c72 AS openvsx-server
+FROM ghcr.io/eclipse/openvsx-server:8fbf749 AS openvsx-server
 
 # UBI Builder
 # https://registry.access.redhat.com/ubi8/ubi
@@ -22,8 +20,8 @@ FROM registry.access.redhat.com/ubi8/ubi:8.8-1009 AS ubi-builder
 RUN mkdir -p /mnt/rootfs
 # Install httpd and postgresql
 RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN yum install --installroot /mnt/rootfs postgresql14-libs postgresql14 postgresql14-server \
-    java-11-openjdk coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source httpd nc \
+RUN yum install --installroot /mnt/rootfs postgresql15-libs postgresql15 postgresql15-server \
+    java-17-openjdk coreutils-single glibc-minimal-langpack glibc-langpack-en langpacks-en glibc-locale-source httpd nc \
     net-tools procps vi curl wget tar gzip jq\
     --releasever 8 --nodocs -y && \
     yum --installroot /mnt/rootfs clean all && \
@@ -45,7 +43,7 @@ RUN cat /mnt/rootfs/etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}:
     && cat /mnt/rootfs/etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > /mnt/rootfs/.group.template
 
 # change permissions
-RUN for f in "/mnt/rootfs/etc/passwd" "/mnt/rootfs/etc/group" "/mnt/rootfs/var/lib/pgsql" "/mnt/rootfs/usr/pgsql-14" "/mnt/rootfs/var/run/postgresql"; do\
+RUN for f in "/mnt/rootfs/etc/passwd" "/mnt/rootfs/etc/group" "/mnt/rootfs/var/lib/pgsql" "/mnt/rootfs/usr/pgsql-15" "/mnt/rootfs/var/run/postgresql"; do\
            chgrp -R 0 ${f} && \
            chmod -R g+rwX ${f}; \
        done
@@ -84,24 +82,24 @@ USER postgres
 ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    PGDATA=/var/lib/pgsql/14/data/database \
+    PGDATA=/var/lib/pgsql/15/data/database \
     # Use a cached version of the license list and not go over the internet
     # it's needed for openvsx server when vsix is publishing on AirGap environment.
     # Set Xmx to run openvsx server
     JVM_ARGS="-DSPDXParser.OnlyUseLocalLicenses=true -Xmx2048m"
 
-RUN /usr/pgsql-14/bin/initdb && \
+RUN /usr/pgsql-15/bin/initdb && \
     # Add all vsix files to the database
     /import-vsix.sh && \
     # add permissions for anyuserid
-    chgrp -R 0 /var/lib/pgsql/14/data/database && \
+    chgrp -R 0 /var/lib/pgsql/15/data/database && \
     #cleanup postgresql pid
-    rm /var/lib/pgsql/14/data/database/postmaster.pid && \
+    rm /var/lib/pgsql/15/data/database/postmaster.pid && \
     rm /var/run/postgresql/.s.PGSQL* && \
     rm /tmp/.s.PGSQL* && \
     rm /tmp/.lock && \
     chmod -R 777 /tmp/file && \
-    chmod -R g+rwX /var/lib/pgsql/14/data/database && mv /var/lib/pgsql/14/data/database /var/lib/pgsql/14/data/old
+    chmod -R g+rwX /var/lib/pgsql/15/data/database && mv /var/lib/pgsql/15/data/database /var/lib/pgsql/15/data/old
 ENTRYPOINT ["/entrypoint.sh"]
 
 # append Brew metadata here

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -58,8 +58,8 @@ function run_main() {
     # start only if wanted
     if [ "${START_OPENVSX}" == "true" ]; then
       # change permissions
-      cp -r /var/lib/pgsql/14/data/old /var/lib/pgsql/14/data/database
-      rm -rf /var/lib/pgsql/14/data/old
+      cp -r /var/lib/pgsql/15/data/old /var/lib/pgsql/15/data/database
+      rm -rf /var/lib/pgsql/15/data/old
 
       # start postgres and openvsx
       ./start-services.sh

--- a/build/dockerfiles/import-vsix.sh
+++ b/build/dockerfiles/import-vsix.sh
@@ -6,13 +6,13 @@ set -o pipefail
 ./start-services.sh
 
 # install temporary nodejs
-mkdir -p /tmp/opt/nodejs && curl -sL https://nodejs.org/download/release/v14.18.3/node-v14.18.3-linux-x64.tar.gz | tar xzf - -C /tmp/opt/nodejs --strip-components=1
+mkdir -p /tmp/opt/nodejs && curl -sL https://nodejs.org/download/release/v18.16.1/node-v18.16.1-linux-x64.tar.gz | tar xzf - -C /tmp/opt/nodejs --strip-components=1
 # add path
 export PATH=/tmp/opt/nodejs/bin:$PATH
 
 
 # install the cli
-npm install -g ovsx@0.7.1
+npm install -g ovsx@0.8.2
 
 # insert user
 psql -c "INSERT INTO user_data (id, login_name) VALUES (1001, 'eclipse-che');"
@@ -135,6 +135,12 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
         vsixUniversalDownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."universal"')
         if [[ $vsixUniversalDownloadLink != null ]]; then
             vsixDownloadLink=$vsixUniversalDownloadLink
+        else
+            # get linux download link
+            vsixLinuxDownloadLink=$(echo "${vsixMetadata}" | jq -r '.downloads."linux-x64"')
+            if [[ $vsixLinuxDownloadLink != null ]]; then
+                vsixDownloadLink=$vsixLinuxDownloadLink
+            fi
         fi
     fi
 

--- a/build/dockerfiles/start-services.sh
+++ b/build/dockerfiles/start-services.sh
@@ -5,10 +5,10 @@ set -o pipefail
 
 # start postgresql
 pushd /var/lib/pgsql || return
-/usr/pgsql-14/bin/postgres &
+/usr/pgsql-15/bin/postgres &
 # wait that postgresql is ready
 printf "Waiting that postgresql is ready"
-timeout 0 bash -c "until /usr/pgsql-14/bin/pg_isready -h 127.0.0.1 -p 5432 -U postgres -q; do printf '.'; sleep 1; done"
+timeout 0 bash -c "until /usr/pgsql-15/bin/pg_isready -h 127.0.0.1 -p 5432 -U postgres -q; do printf '.'; sleep 1; done"
 echo "Database is ready"
 
 # start openvsx


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Updates openvsx image to use more freshest openvsx-server in the embedded plugin registry;
- Upgrades postgresql to 15 version
- Upgrade java to 17 version
- Upgrades ovsx to 0.8.2 version

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![screenshot-nimbusweb me-2023 07 13-17_20_05](https://github.com/eclipse-che/che-plugin-registry/assets/1271546/7158a3b5-e479-4fc7-9e70-d437b143a2e2)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22247

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Deploy che
- Update eclipse-che CR to use internal plugin registry with custom image:
```
    pluginRegistry:
      deployment:
        containers:
          - image: 'quay.io/vsvydenk/che-plugin-registry:13'
      openVSXURL: ''
```
- Start any workspace and check that plugins are available in the Plugins view and it's possible to install them:
![screenshot-eclipse-che apps rosa n6dig-qxxtm-m8i krbb p3 openshiftapps com-2023 07 14-14_33_55](https://github.com/eclipse-che/che-plugin-registry/assets/1271546/4ab1a2ba-d68c-458b-a77c-1704b8781796)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
