### PR TITLE
Fix: use gh instead of hub for Che #22646

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -101,7 +101,6 @@ commitChangeOrCreatePR()
       git checkout "${PR_BRANCH}"
       git pull origin "${PR_BRANCH}"
       git push origin "${PR_BRANCH}"
-      lastCommitComment="$(git log -1 --pretty=%B)"
       gh pr create -f -B "${aBRANCH}" -H "${PR_BRANCH}"
     fi
   fi

--- a/make-release.sh
+++ b/make-release.sh
@@ -102,7 +102,7 @@ commitChangeOrCreatePR()
       git pull origin "${PR_BRANCH}"
       git push origin "${PR_BRANCH}"
       lastCommitComment="$(git log -1 --pretty=%B)"
-      hub pull-request -f -m "${lastCommitComment}" -b "${aBRANCH}" -h "${PR_BRANCH}"
+      gh pr create -f -B "${aBRANCH}" -H "${PR_BRANCH}"
     fi
   fi
 }


### PR DESCRIPTION
### What does this PR do?
Updates make-release.sh to use gh instead of hub

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22646

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
