### PR TITLE
Get rid of failing curl in OpenShift CI jobs

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -11,25 +11,19 @@
 #   Red Hat, Inc. - initial API and implementation
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.access.redhat.com/ubi9/nodejs-18:1
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 # hadolint ignore=DL3002
 USER 0
 
-# hadolint ignore=DL3041
-RUN dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs psmisc python3-pip jq golang httpd-tools \
-    # already installed or installed as deps:
-    openssl openssl-devel ca-certificates make cmake cpp gcc gcc-c++ zlib zlib-devel brotli brotli-devel python3 nodejs-packaging && \
-    dnf update -y && dnf clean all && \
-    npm install -g yarn@1.22 npm@9 && \
-    echo -n "node version: "; node -v; \
-    echo -n "npm  version: "; npm -v; \
-    echo -n "yarn version: "; yarn -v;
+SHELL ["/bin/bash", "-c"]
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+# Install yq, kubectl, chectl cli used by olm/olm.sh script.
+# hadolint ignore=DL3041
+# Install yq, kubectl, chectl cli.
+RUN yum install --assumeyes -d1 psmisc python3-pip  httpd-tools nodejs && \
+    pip3 install --upgrade setuptools && \
+    pip3 install yq && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
-    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next && \
-    curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.6/linux/oc.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
-    chmod ug+x /usr/local/bin/oc
-
-SHELL ["/bin/bash", "-c"]
+    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next


### PR DESCRIPTION
### What does this PR do?
Gets rid of faulty "curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.8/openshift-client-linux.tar.gz" command in OpenShift CI jobs (it was an idea of @artaleks9).

Fixing error example: https://storage.googleapis.com/test-platform-results/pr-logs/pull/eclipse-che_che-plugin-registry/1870/pull-ci-eclipse-che-che-plugin-registry-main-v14-plugins-test-pr-check/1747174582978088960/build-log.txt
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
error: build error: building at STEP "RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin &&     bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next &&     curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.6/linux/oc.tar.gz | tar xvzf - -C /usr/local/bin/ oc &&     chmod ug+x /usr/local/bin/oc": while running runtime: exit status 2
```

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-5370


### How to test this PR?
Look at OpenShift CI job execution results in PR

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
