### PR TITLE
chore: upgrade local plugin registry to use openvsx-server 0.14.3

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@
 #
 
 # OpenVSX
-FROM ghcr.io/eclipse/openvsx-server:v0.14.1 AS openvsx-server
+FROM ghcr.io/eclipse/openvsx-server:v0.14.3 AS openvsx-server
 
 # UBI Builder
 # https://registry.access.redhat.com/ubi8/ubi

--- a/build/dockerfiles/import-vsix.sh
+++ b/build/dockerfiles/import-vsix.sh
@@ -198,6 +198,9 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
     # publish the file
     ovsx publish "${vsixFilename}"
 
+    # wait for the extension to be published
+    sleep 15
+
     # remove the downloaded file
     rm "${vsixFilename}"
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Upgrade openvsx-server base image to 0.14.3
- Set timeout after publishing an extension for the activation

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![screenshot-nimbusweb me-2024 03 19-14_59_04](https://github.com/eclipse-che/che-plugin-registry/assets/1271546/6a21b0dc-0a63-48c0-a41c-7df27e28d4bd)

![screenshot-nimbusweb me-2024 03 19-14_56_30](https://github.com/eclipse-che/che-plugin-registry/assets/1271546/49f7ed30-8d91-4a24-a111-0b1a33eff2a0)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22826

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Deploy Eclipse Che on the cluster
- Update che-server CR in the OS console to use custom plugin registry:
```yaml
    pluginRegistry:
      deployment:
        containers:
          - image: 'quay.io/vsvydenk/che-plugin-registry:14.3'
      openVSXURL: ''
```
- Start any workspace
- Extensions should be available on the extension's view and it should be possible to install any extension

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
