### PR TITLE
chore: add Tech-Preview tag into editors' definitions

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -37,6 +37,8 @@ Here is the expected format of a [`che-editors.yaml`](./che-editors.yaml) editor
       displayName: Jupyter Notebook
       description: Jupyter Notebook for Eclipse Che
       icon: /images/notebook.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: ws-skeleton
         version: 5.7.0
@@ -77,6 +79,9 @@ Here are all the supported values, including optional ones:
       description: Run Editor Foo on top of Eclipse Che
       # Editor's icon. The icon should be located in /images folder.
       icon: /images/editor_icon.svg
+      # (OPTIONAL) Array of tags of the current editor. Tech-Preview means it's considered experimental and is not recommended for production environments. While it can include new features and improvements, it may still contain bugs or undergo significant changes before reaching a stable version. 
+      tags:
+        - Tech-Preview
       # (OPTIONAL) Additional attributes
       attributes:
         title: This is my editor

--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -6,6 +6,8 @@ editors:
       displayName: Jupyter Notebook
       description: Jupyter Notebook for Eclipse Che
       icon: /images/notebook.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: ws-skeleton
         version: 5.7.0
@@ -37,6 +39,8 @@ editors:
       displayName: Eclipse Dirigible
       description: Eclipse Dirigible for Eclipse Che
       icon: /images/dirigible.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: dirigiblelabs
         version: 3.4.0
@@ -86,6 +90,8 @@ editors:
       displayName: Eclipse IDE with Broadway
       description: Eclipse IDE (in browser using Broadway) for Eclipse Che
       icon: /images/eclipse-ide.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: ws-skeleton
         version: 4.9.0
@@ -115,6 +121,8 @@ editors:
       description: An open source distribution of Visual Studio Code (code-server)
         for Eclipse Che
       icon: /images/vscode.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: cdr
         version: 3.6.2
@@ -150,6 +158,8 @@ editors:
       description: Microsoft Visual Studio Code - Open Source IDE for Eclipse Che
         - Insiders build
       icon: /images/vscode.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: insiders
@@ -325,6 +335,8 @@ editors:
       displayName: IntelliJ IDEA Community
       description: JetBrains IntelliJ IDEA Community IDE for Eclipse Che - next
       icon: /images/intellij-idea.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: next
@@ -431,6 +443,8 @@ editors:
       displayName: IntelliJ IDEA Community
       description: JetBrains IntelliJ IDEA Community IDE for Eclipse Che
       icon: /images/intellij-idea.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: latest
@@ -537,6 +551,8 @@ editors:
       displayName: JetBrains PyCharm Community
       description: JetBrains PyCharm Community IDE for Eclipse Che - next
       icon: /images/pycharm.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: next
@@ -643,6 +659,8 @@ editors:
       displayName: JetBrains PyCharm Community
       description: JetBrains PyCharm Community IDE for Eclipse Che
       icon: /images/pycharm.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: latest
@@ -749,6 +767,8 @@ editors:
       displayName: IntelliJ IDEA Ultimate (desktop)
       description: JetBrains IntelliJ IDEA Ultimate dev server for Eclipse Che - next
       icon: /images/intellij-idea.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: next
@@ -815,6 +835,8 @@ editors:
       displayName: IntelliJ IDEA Ultimate (desktop)
       description: JetBrains IntelliJ IDEA Ultimate dev server for Eclipse Che - latest
       icon: /images/intellij-idea.svg
+      tags:
+        - Tech-Preview
       attributes:
         publisher: che-incubator
         version: latest

--- a/tools/build/src/devfle-yaml/index-writer.ts
+++ b/tools/build/src/devfle-yaml/index-writer.ts
@@ -57,6 +57,7 @@ export class IndexWriter {
         links: {
           devfile: `/v3/plugins/${id}/devfile.yaml`,
         },
+        tags: metadata.tags,
         name: name,
         publisher: publisher,
         type: this.CHE_EDITOR_TYPE,

--- a/tools/build/tests/devfile-yaml/index-writer.spec.ts
+++ b/tools/build/tests/devfile-yaml/index-writer.spec.ts
@@ -31,8 +31,8 @@ describe('Test IndexWriter', () => {
           displayName: 'display-name',
           description: 'my-description',
           icon: '/images/idea.svg',
+          tags: ['my-tag', 'Tech-Preview'],
           attributes: {
-            tags: ['my-tag'],
             icon: 'my-icon',
             category: 'my-category',
             version: 'latest',
@@ -107,6 +107,8 @@ describe('Test IndexWriter', () => {
     expect(jsonOutput[1].type).toBe('Che Editor');
     expect(jsonOutput[1].version).toBe('latest');
     expect(jsonOutput[1].icon).toBe('/v3/images/idea.svg');
+    expect(jsonOutput[1].tags[0]).toBe('my-tag');
+    expect(jsonOutput[1].tags[1]).toBe('Tech-Preview');
 
     expect(jsonOutput[2].id).toBe('my-publisher/my-name/latest');
     expect(jsonOutput[2].description).toBe('my-description');


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds Tech-Preview tag for all editors except **che-code/latest**

<details>
  <summary>index.json content:</summary>

```json
[
  {
    "id": "cdr/code-server/latest",
    "description": "An open source distribution of Visual Studio Code (code-server) for Eclipse Che",
    "displayName": "VS Code via code-server",
    "links": {
      "devfile": "/v3/plugins/cdr/code-server/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "code-server",
    "publisher": "cdr",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/vscode.svg"
  },
  {
    "id": "che-incubator/che-code/insiders",
    "description": "Microsoft Visual Studio Code - Open Source IDE for Eclipse Che - Insiders build",
    "displayName": "VS Code - Open Source",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-code/insiders/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "che-code",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "insiders",
    "icon": "/v3/images/vscode.svg"
  },
  {
    "id": "che-incubator/che-code/latest",
    "description": "Microsoft Visual Studio Code - Open Source IDE for Eclipse Che",
    "displayName": "VS Code - Open Source",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-code/latest/devfile.yaml"
    },
    "name": "che-code",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/vscode.svg"
  },
  {
    "id": "che-incubator/che-idea-server/latest",
    "description": "JetBrains IntelliJ IDEA Ultimate dev server for Eclipse Che - latest",
    "displayName": "IntelliJ IDEA Ultimate (desktop)",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-idea-server/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "che-idea-server",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/intellij-idea.svg"
  },
  {
    "id": "che-incubator/che-idea-server/next",
    "description": "JetBrains IntelliJ IDEA Ultimate dev server for Eclipse Che - next",
    "displayName": "IntelliJ IDEA Ultimate (desktop)",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-idea-server/next/devfile.yaml"
    },
    "tags": [
      "IntelliJ IDEA",
      "Tech-Preview"
    ],
    "name": "che-idea-server",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "next",
    "icon": "/v3/images/intellij-idea.svg"
  },
  {
    "id": "che-incubator/che-idea/latest",
    "description": "JetBrains IntelliJ IDEA Community IDE for Eclipse Che",
    "displayName": "IntelliJ IDEA Community",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-idea/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "che-idea",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/intellij-idea.svg"
  },
  {
    "id": "che-incubator/che-idea/next",
    "description": "JetBrains IntelliJ IDEA Community IDE for Eclipse Che - next",
    "displayName": "IntelliJ IDEA Community",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-idea/next/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "che-idea",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "next",
    "icon": "/v3/images/intellij-idea.svg"
  },
  {
    "id": "che-incubator/che-pycharm/latest",
    "description": "JetBrains PyCharm Community IDE for Eclipse Che",
    "displayName": "JetBrains PyCharm Community",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-pycharm/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "che-pycharm",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/pycharm.svg"
  },
  {
    "id": "che-incubator/che-pycharm/next",
    "description": "JetBrains PyCharm Community IDE for Eclipse Che - next",
    "displayName": "JetBrains PyCharm Community",
    "links": {
      "devfile": "/v3/plugins/che-incubator/che-pycharm/next/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "che-pycharm",
    "publisher": "che-incubator",
    "type": "Che Editor",
    "version": "next",
    "icon": "/v3/images/pycharm.svg"
  },
  {
    "id": "dirigiblelabs/dirigible/latest",
    "description": "Eclipse Dirigible for Eclipse Che",
    "displayName": "Eclipse Dirigible",
    "links": {
      "devfile": "/v3/plugins/dirigiblelabs/dirigible/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "dirigible",
    "publisher": "dirigiblelabs",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/dirigible.svg"
  },
  {
    "id": "ws-skeleton/eclipseide/latest",
    "description": "Eclipse IDE (in browser using Broadway) for Eclipse Che",
    "displayName": "Eclipse IDE with Broadway",
    "links": {
      "devfile": "/v3/plugins/ws-skeleton/eclipseide/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "eclipseide",
    "publisher": "ws-skeleton",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/eclipse-ide.svg"
  },
  {
    "id": "ws-skeleton/jupyter/latest",
    "description": "Jupyter Notebook for Eclipse Che",
    "displayName": "Jupyter Notebook",
    "links": {
      "devfile": "/v3/plugins/ws-skeleton/jupyter/latest/devfile.yaml"
    },
    "tags": [
      "Tech-Preview"
    ],
    "name": "jupyter",
    "publisher": "ws-skeleton",
    "type": "Che Editor",
    "version": "latest",
    "icon": "/v3/images/notebook.svg"
  }
]
```

</details>


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
part of https://github.com/eclipse/che/issues/22879

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
check [index.json](https://pr-check-1901-che-plugin-registry.surge.sh/index.json) on surge.sh in the PR check

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
