### PR TITLE
docs: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Eclipse Che Plugin Registry
 
+> **Deprecation Notice:** The embedded plugin registry is deprecated. Setting up an internal, on-premises Open VSX registry provides full control over the extension lifecycle, enables offline use, and improves compliance. Refer to the [Running the Open VSX On-Premises](https://eclipse.dev/che/docs/stable/administration-guide/running-the-open-vsx-on-premises/) procedure for detailed setup instructions.
+
 This repository holds editor definitions and ready-to-use plugins for different languages and technologies as part of the embedded instance of the [Open VSX](https://open-vsx.org/about) registry to support air-gapped, offline, and proxy-restricted environments. The embedded Open VSX registry contains only a subset of the extensions published on open-vsx.org that can be used with Microsoft Visual Studio Code editor.
 
 Current build from the main branch is available at [https://eclipse-che.github.io/che-plugin-registry/main/](https://eclipse-che.github.io/che-plugin-registry/main/).


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
  - Add a deprecation notice for the embedded plugin registry to the README
  - Recommend setting up an internal, on-premises Open VSX registry for full control over the extension lifecycle, offline use, and compliance
  - Link to the "Running the Open VSX On-Premises" setup procedure

