### PR TITLE
fix: add OCI media types to registry manifest Accept header

### DIFF
--- a/tools/build/src/registry/registry-helper.ts
+++ b/tools/build/src/registry/registry-helper.ts
@@ -96,8 +96,12 @@ export class RegistryHelper {
     }
 
     // use custom headers to correctly grab all information
-    headers['Accept'] =
-      'application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json';
+    headers['Accept'] = [
+      'application/vnd.oci.image.manifest.v1+json',
+      'application/vnd.oci.image.index.v1+json',
+      'application/vnd.docker.distribution.manifest.v2+json',
+      'application/vnd.docker.distribution.manifest.list.v2+json',
+    ].join(',');
 
     // to workaround that JSON is tried on response even if text is specified, use arraybuffer instead
     // we really need untouched raw content as we're using content to apply sha256 on it

--- a/tools/build/src/registry/registry-helper.ts
+++ b/tools/build/src/registry/registry-helper.ts
@@ -97,7 +97,7 @@ export class RegistryHelper {
 
     // use custom headers to correctly grab all information
     headers['Accept'] =
-      'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json';
+      'application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json';
 
     // to workaround that JSON is tried on response even if text is specified, use arraybuffer instead
     // we really need untouched raw content as we're using content to apply sha256 on it


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Quay.io returns a legacy Schema v1 manifest when only Docker v2 media types are requested, and Schema v1 manifests are not content-addressable by digest, causing a 404 during digest verification. Adding OCI media types (application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json) to the Accept header ensures the registry returns a proper OCI manifest index that can be resolved by digest.
