### PR TITLE
fix: handle paging when fetching versions for import-vsix.sh

### DIFF
--- a/build/dockerfiles/import-vsix.sh
+++ b/build/dockerfiles/import-vsix.sh
@@ -55,14 +55,21 @@ getMetadata(){
     done
 }
 
-versionsPage=""
+allVersions=""
 getVersions(){
     vsixName=$1
-    # check the versions page is empty and retry if it is
+    local totalSize=-1
+    local offset=0
+    local apiResponse=""
+
+    # Initialize allVersions for this call
+    allVersions="{}"
+
+    # Fetch first page to get totalSize
     for j in 1 2 3 4 5
     do
-        versionsPage=$(curl -sLS "https://open-vsx.org/api/${vsixName}/versions?size=600")
-        totalSize=$(echo "${versionsPage}" | jq -r ".totalSize")
+        apiResponse=$(curl -sLS "https://open-vsx.org/api/${vsixName}/versions?size=100&offset=0")
+        totalSize=$(echo "${apiResponse}" | jq -r ".totalSize")
         if [[ "$totalSize" != "null" && "$totalSize" -eq 0 ]]; then
             echo "Attempt $j/5: Error while getting versions for ${vsixName}"
 
@@ -74,6 +81,33 @@ getVersions(){
         else
             break
         fi
+    done
+
+    # Merge first page versions
+    allVersions=$(echo "$allVersions $(echo "${apiResponse}" | jq -r '.versions')" | jq -s '.[0] * .[1]')
+    offset=100
+
+    # Fetch remaining pages if needed
+    while [[ $offset -lt $totalSize ]]; do
+        for j in 1 2 3 4 5
+        do
+            local versions
+            apiResponse=$(curl -sLS "https://open-vsx.org/api/${vsixName}/versions?size=100&offset=${offset}")
+            versions=$(echo "${apiResponse}" | jq -r ".versions")
+            if [[ "$versions" != "null" ]]; then
+                # Merge current page versions
+                allVersions=$(echo "$allVersions $versions" | jq -s '.[0] * .[1]')
+                break
+            else
+                echo "Attempt $j/5: Error while getting versions for ${vsixName} at offset ${offset}"
+                if [[ $j -eq 5 ]]; then
+                    echo "[ERROR] Maximum of 5 attempts reached - must exit!"
+                    exit 1
+                fi
+                continue
+            fi
+        done
+        offset=$((offset + 100))
     done
 }
 
@@ -121,8 +155,7 @@ for i in $(seq 0 "$((numberOfExtensions - 1))"); do
             getMetadata "${vsixName}" "latest"
             getVersions "${vsixName}"
             # if version wasn't set in json, grab it from metadata and add it into the file
-            # get all versions of the extension
-            allVersions=$(echo "${versionsPage}" | jq -r '.versions')
+            # get all versions of the extension (allVersions is set by getVersions)
             if [[ "$allVersions" == "{}" ]]; then
                 echo "No versions found for ${vsixName}"
                 exit 1


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.5

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix current build failing because import-vsix.sh script failing to get more than 100 elements per 1 API request

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23885

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
run build.sh locally to see the build pass

#### Release Notes
<!-- markdown to be included in marketing announcement -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
